### PR TITLE
[KU-41] feat: 성향 테스트 화면 UI 구현

### DIFF
--- a/app/signup/_layout.tsx
+++ b/app/signup/_layout.tsx
@@ -4,7 +4,7 @@ export default function SignupLayout() {
     return (
         <Stack screenOptions={{ headerShown: false}}>
             <Stack.Screen name="nickname" />
-            {/* <Stack.Screen name="style-test" options={{ animation: "none"}} /> */}
+            <Stack.Screen name="style-test" options={{ animation: "none"}} />
         </Stack>
     )
 }

--- a/app/signup/style-test.tsx
+++ b/app/signup/style-test.tsx
@@ -1,0 +1,147 @@
+import { useState, useMemo, useCallback } from "react";
+import { View, KeyboardAvoidingView, Platform, SafeAreaView, 
+    ScrollView, NativeSyntheticEvent, NativeScrollEvent
+ } from "react-native";
+import { useRouter } from "expo-router";
+
+import SignupTitle from "@/components/titles/SignupTitle";
+import SignupBar from "@/components/bars/SignupBar";
+import StyleQuestionList from "@/components/list/StyleQuestionList";
+import SignupButton from "@/components/buttons/SignupButton";
+
+const BUTTON_HEIGHT = 88;
+
+const questions = [
+        {
+            id: 1,
+            question: "나는 콘서트에서 노래가 나오면",
+            options: ["노래를 함께 따라 부르는 편이다", "조용히 감상만 하는 편이다"],
+        },
+        {
+            id: 2,
+            question: "나는 좋아하는 가수의 굿즈샵에서",
+            options: ["굿즈를 구경하고 종종 구매하는 편이다", "굿즈에 돈을 쓰지 않는 편이다"],
+        },
+        {
+            id: 3,
+            question: "옆자리 초면인 사람과",
+            options: ["쉽게 친해지고 이야기를 나누는 편이다", "말을 걸지 않는 편이다"],
+        },
+        {
+            id: 4,
+            question: "내가 좋아하는 장르는",
+            options: ["스펙트럼이 넓고 다양한 편이다", "소수이고 마이너하다"],
+        },
+    ];
+
+export default function StyleTest() {
+    const router = useRouter();
+
+    const [answers, setAnswers] = useState<{ [key: number]: number | null }>({});
+
+    const [atBottom, setAtBottom] = useState(false);
+    const [viewportH, setViewportH] = useState(0);
+    const [contentH, setContentH] = useState(0);
+
+    const canSubmit = useMemo(() => {
+        return questions.every(q => answers[q.id] !== undefined);
+    }, [answers]);
+
+
+    async function onSubmit() {
+        if (!canSubmit) return;
+        router.push("/event"); 
+    }
+
+    const handleScroll = useCallback((e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const { layoutMeasurement, contentOffset, contentSize } = e.nativeEvent;
+
+    const reachThreshold = 40;
+    const releaseThreshold = 80;
+
+    const bottomLine = contentSize.height - layoutMeasurement.height;
+
+    if (!atBottom) {
+      if (contentOffset.y >= bottomLine - reachThreshold) {
+        setAtBottom(true);
+      }
+    } else {
+      if (contentOffset.y <= bottomLine - releaseThreshold) {
+        setAtBottom(false);
+      }
+    }
+  }, [atBottom]);
+
+  const handleLayout = useCallback((e: any) => {
+    setViewportH(e.nativeEvent.layout.height);
+  }, []);
+
+  const handleContentSizeChange = useCallback((_w: number, h: number) => {
+    setContentH(h);
+  }, []);
+
+  const showButton = atBottom || contentH <= viewportH;
+
+    return (
+        <SafeAreaView className="flex-1 bg-white">
+            <KeyboardAvoidingView
+                className="flex-1"
+                behavior={Platform.OS === "ios" ? "padding" : undefined}
+            >
+            <View className="flex-1">
+                <ScrollView
+                    className="flex-1"
+                    contentContainerStyle={{ paddingBottom: BUTTON_HEIGHT }} // 항상 동일
+                    keyboardShouldPersistTaps="handled"
+                    keyboardDismissMode="on-drag"
+                    onScroll={handleScroll}
+                    scrollEventThrottle={16}
+                    onLayout={handleLayout}
+                    onContentSizeChange={handleContentSizeChange}
+                >
+                    <SignupBar 
+                        progressWidth="w-1/2"
+                        showBack={true}
+                        onBack={() => router.back()}
+                    />
+                    <SignupTitle 
+                        mainText="Style Test" 
+                        subText="성향에 맞게 응답해주세요" 
+                        showIcon={false} 
+                    />
+                    
+                    <StyleQuestionList
+                        questions={questions}
+                        answers={answers}
+                        onSelect={(id, idx) =>
+                        setAnswers((prev) => ({ ...prev, [id]: idx }))
+                        }
+                    />
+                </ScrollView>
+
+                <View
+                    style={{
+                    position: "absolute",
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    opacity: showButton ? 1 : 0,
+                    pointerEvents: showButton ? "auto" : "none",
+                    }}
+                >
+                {showButton && (
+                    <SignupButton
+                        label="다음"
+                        onPress={onSubmit}
+                        disabled={!canSubmit}
+                        noMargin
+                    />
+                )}
+                </View>
+            </View>
+            </KeyboardAvoidingView>
+        </SafeAreaView>
+
+    );
+
+}

--- a/app/signup/style-test.tsx
+++ b/app/signup/style-test.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "expo-router";
 
 import SignupTitle from "@/components/titles/SignupTitle";
 import SignupBar from "@/components/bars/SignupBar";
-import StyleQuestionList from "@/components/list/StyleQuestionList";
+import StyleQuestionList from "@/components/lists/StyleQuestionList";
 import SignupButton from "@/components/buttons/SignupButton";
 
 const BUTTON_HEIGHT = 88;

--- a/components/buttons/SignupButton.tsx
+++ b/components/buttons/SignupButton.tsx
@@ -1,4 +1,4 @@
-import { View, Text, TouchableOpacity } from "react-native";
+import { View, Text, TouchableOpacity, ViewStyle } from "react-native";
 import { fonts } from "../../constants/fonts";
 import { colors } from "../../constants/colors";
 
@@ -6,25 +6,30 @@ type SignupButtonProps = {
   label: string;
   onPress: () => void;
   disabled?: boolean;
+  noMargin?: boolean;
+  containerStyle?: ViewStyle;
 };
 
 export default function SignupButton({
   label,
   onPress,
   disabled = false,
+  noMargin = false,
+  containerStyle,
 }: SignupButtonProps) {
   return (
-    <View className="px-6 mt-8">
+    <View className={["px-6", noMargin ? "" : "mt-8"].join(" ")} style={containerStyle}>
       <TouchableOpacity
         className="w-full rounded-md py-6 items-center"
         style={{
           backgroundColor: disabled ? colors.gray : colors.orange,
+          paddingVertical: 18,
         }}
         onPress={onPress}
         disabled={disabled}
       >
         <Text
-          style={[fonts.largeText, { color: colors.white }]}
+          style={[fonts.largeText, { color: colors.white, lineHeight: 24 }]}
         >
           {label}
         </Text>

--- a/components/lists/StyleQuestionList.tsx
+++ b/components/lists/StyleQuestionList.tsx
@@ -1,0 +1,61 @@
+import { View, Text, TouchableOpacity } from "react-native";
+import { fonts } from "@/constants/fonts";
+import { colors } from "@/constants/colors"
+
+type Question = {
+  id: number;
+  question: string;
+  options: string[];
+};
+
+type StyleQuestionListProps = {
+  questions: Question[];
+  answers: { [key: number]: number | null };
+  onSelect: (questionId: number, optionIdx: number) => void;
+};
+
+export default function StyleQuestionList({
+  questions,
+  answers,
+  onSelect,
+}: StyleQuestionListProps) {
+  return (
+    <View className="px-6">
+      {questions.map((q) => (
+        <View key={q.id} className="mb-8">
+          <Text style={[fonts.mediumText, { marginBottom: 12 }]}>
+            {q.id}. {q.question}
+          </Text>
+
+          {q.options.map((opt, idx) => {
+            const selected = answers[q.id] === idx;
+            return (
+              <TouchableOpacity
+                key={idx}
+                className="w-full rounded-md py-4 px-4 mb-3"
+                style={{
+                  backgroundColor: selected ? colors.orange : colors.white,
+                  borderColor: selected ? colors.orange : colors.gray,
+                  borderWidth: 1,
+                }}
+                onPress={() => onSelect(q.id, idx)}
+              >
+                <Text
+                  style={[
+                    fonts.mediumText,
+                    { fontSize: 15, 
+                      color: selected ? colors.white : colors.black,
+                    },
+                  ]}
+                >
+                  {idx === 0 ? "A. " : "B. "}
+                  {opt}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      ))}
+    </View>
+  );
+}


### PR DESCRIPTION
## 🔷 관련 Jira Ticket ID

[KU-41]

---
## 📌 작업 내용 및 특이사항

- StyleTest 화면 UI를 구현하였습니다.
  - 공용 컴포넌트 `SignupBar`, `SignupTitle`, `SignupButton`을 재사용하였습니다.
  - 질문 목록을 재사용 가능한 `StyleQuestionList` 컴포넌트로 분리하였습니다.
  - 스크롤 최하단에 도달하거나 콘텐츠가 화면보다 작을 때만 하단 버튼이 표시되도록 스크롤 로직을 구현하였습니다.
  - 질문 목록은 임시 데이터로 구성되어 있으며 추후 API 연동 시 수정예정입니다.

---
## 📚 참고사항

- 버튼 표시 조건을 atBottom 상태와 콘텐츠/뷰포트 비교(contentH <= viewportH)로 관리합니다.
- 질문 목록 API 연동 시 진행 상황을 표시하는 Progress Bar UI를 추가할 예정입니다.
<img width="516" height="408" alt="image" src="https://github.com/user-attachments/assets/3b65f7d5-5b6d-4db8-9b91-ce9244a5532b" />



[KU-41]: https://judymoody59.atlassian.net/browse/KU-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ