### PR TITLE
[KU-93] feat: 파티 목록 화면 UI 구현

### DIFF
--- a/app/event-list.tsx
+++ b/app/event-list.tsx
@@ -1,8 +1,21 @@
-import { View } from "react-native";
+import React from "react";
+import { View,ScrollView } from "react-native";
+import EventList from "@/components/lists/EventList";
 
 export default function EventListScreen(){
+
     return (
         <View className="flex-1 bg-white">
+            <ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={{ flexGrow: 1, paddingBottom: 0 }}>
+                <EventList 
+                    searchEvent={null}
+                    countEventNum={null}
+                    isSearched={false}
+                    isAllEventMode={true}
+                />
+        </ScrollView>
         </View>
     );
 }

--- a/app/main-e.tsx
+++ b/app/main-e.tsx
@@ -24,6 +24,7 @@ export default function MainEventScreen(){
                     searchEvent={searchEvent}
                     countEventNum={countEventNum}
                     isSearched={isSearched}
+                    isAllEventMode={false}
                 />
         </ScrollView>
         </View>

--- a/app/party-list.tsx
+++ b/app/party-list.tsx
@@ -1,8 +1,71 @@
-import { View } from "react-native";
+import React, { useState } from "react";
+import { ScrollView, TouchableOpacity } from "react-native";
+import PartyList from "@/components/lists/PartyList";
+import PartyBottomSheet from "@/components/lists/PartyBottomSheet";
+
+import type { PartyItem } from "@/types/party";
+import { parties } from "@/mocks/parties";
+import { colors } from "@/constants/colors";
+import PartyListTitle from "@/components/titles/PartyListTitle";
+import PartyListButtons from "@/components/buttons/PartyListButtons";
 
 export default function PartyListScreen(){
-    return (
-        <View className="flex-1 bg-white">
-        </View>
+  
+  const [partyData, setPartyData] = useState(parties);
+  const [selectedTab, setSelectedTab] = useState<"ALL" | "MY">("ALL");
+
+  const [selectedPartyId, setSelectedPartyId] = useState<number | null>(null);
+  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+  
+  const selectedParty =
+    partyData.find((party) => party.partyId === selectedPartyId) ?? null;
+
+  const handleToggleLike = (id: number) => {
+    setPartyData(prev =>
+      prev.map(item =>
+        item.partyId === id ? { ...item, isLiked: !item.isLiked } : item
+      )
     );
+  };
+
+  const handleSelectParty = (party: PartyItem) => {
+      setSelectedPartyId(party.partyId);
+      setIsBottomSheetOpen(true);
+  };
+
+  const clearSelection = () => {
+    if (!isBottomSheetOpen) setSelectedPartyId(null);
+  };
+
+  return (
+    <>
+      <TouchableOpacity 
+        activeOpacity={1} 
+        style={{ flex: 1 }} 
+        onPress={clearSelection}
+      >
+        <ScrollView className="flex-1" style={{ backgroundColor: colors.white }}>
+          <PartyListTitle />
+          <PartyListButtons 
+            selectedTab={selectedTab}
+            onChangeTab={setSelectedTab}
+          />
+          <PartyList 
+            partyData={partyData} 
+            countPartyNum={10}
+            onToggleLike={handleToggleLike}
+            onSelectParty={handleSelectParty}
+            selectedPartyId={selectedPartyId}
+          />
+        </ScrollView>
+      </TouchableOpacity>
+
+      <PartyBottomSheet
+        isVisible={isBottomSheetOpen}
+        party={selectedParty}
+        onClose={() => { setIsBottomSheetOpen(false);}}
+        onToggleLike={handleToggleLike}
+      />
+    </>
+  );
 }

--- a/components/buttons/PartyListButtons.tsx
+++ b/components/buttons/PartyListButtons.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { View, TouchableOpacity, Text } from "react-native";
+import { colors } from "@/constants/colors";
+import { fonts } from "@/constants/fonts";
+
+type TabType = "ALL" | "MY";
+
+type PartyListButtonsProps = {
+  selectedTab: TabType;
+  onChangeTab: (tab: TabType) => void;
+};
+
+export default function PartyListButtons({ selectedTab, onChangeTab }: PartyListButtonsProps) {
+  const tabs = [
+    { key: "ALL" as TabType, label: "전체", color: colors.orange },
+    { key: "MY" as TabType, label: "MY", color: colors.green },
+  ];
+
+  return (
+    <View className="px-5 items-end mt-1">
+      <View className="flex-row">
+        {tabs.map((tab, index) => {
+          const isActive = selectedTab === tab.key;
+
+          return (
+            <TouchableOpacity
+              key={tab.key}
+              className={`px-6 py-2 rounded-t-2xl ${
+                index === 0 ? "mr-2" : ""
+              }`}
+              style={{
+                backgroundColor: isActive ? tab.color : colors. gray,
+              }}
+              onPress={() => onChangeTab(tab.key)}
+            >
+              <Text style={[fonts.mediumText, { color: colors.white, fontSize: 15 }]}>
+                {tab.label}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+
+      <View
+        className="h-[3px] w-full"
+        style={{
+          backgroundColor:
+            selectedTab === "ALL" ? colors.orange : colors.green,
+        }}
+      />
+    </View>
+  );
+}

--- a/components/lists/EventList.tsx
+++ b/components/lists/EventList.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { useNavigation } from "@react-navigation/native";
 import type { NavigationProp } from "@react-navigation/native";
 import type { RootTabParamList } from "@/app/navigation/_types";
-import type { MainStackParamList } from "@/app/navigation/MainStack";
 import { View, Text, Image, TouchableOpacity } from "react-native";
 import { events } from "@/mocks/events";
 import { colors } from "@/constants/colors";
@@ -10,18 +9,21 @@ import EventListTitle from "../titles/EventListTitle";
 import EmptyBox from "./EmptyBox";
 
 interface EventListProps {
-  searchEvent?: string;
+  searchEvent?: string | null;
   countEventNum?: number | null;
   isSearched?: boolean;
+  isAllEventMode?: boolean;
 }
 
 export default function EventList({ 
-  searchEvent="", countEventNum, isSearched = false, 
+  searchEvent="", countEventNum, isSearched = false, isAllEventMode = false, 
 }: EventListProps) {
 
   const navigation = useNavigation<NavigationProp<RootTabParamList>>();
   
-  const title = isSearched
+  const title = isAllEventMode
+    ? "모든 행사 보기"
+    : isSearched
     ? `검색 결과 (${countEventNum ?? 0})`
     : "실시간 인기 있는 행사";
 
@@ -38,7 +40,8 @@ export default function EventList({
             key={item.eventId}
             activeOpacity={0.8}
             className="flex-row items-center mb-5"
-            onPress={() =>
+            onPress={() => {
+              if (isAllEventMode) return;
               navigation.navigate("MainStack", {
                 screen: "MainPartyScreen",
                 params: {
@@ -48,7 +51,7 @@ export default function EventList({
                   endDate: item.endDate,
                 },
               })
-            }
+            }}
           >
             <Image
               source={{ uri: item.posterUrl }}

--- a/components/titles/PartyListTitle.tsx
+++ b/components/titles/PartyListTitle.tsx
@@ -9,7 +9,7 @@ export default function PartyListTitle() {
       <Text
         style={[
           fonts.mediumText,
-          { fontSize: 26, color: colors.black }
+          { fontSize: 21, color: colors.black }
         ]}
       >
         파티 목록

--- a/components/titles/PartyListTitle.tsx
+++ b/components/titles/PartyListTitle.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { View, Text } from "react-native";
+import { fonts } from "@/constants/fonts";
+import { colors } from "@/constants/colors";
+
+export default function PartyListTitle() {
+  return (
+    <View className="px-5 mt-6 mb-0">
+      <Text
+        style={[
+          fonts.mediumText,
+          { fontSize: 26, color: colors.black }
+        ]}
+      >
+        파티 목록
+      </Text>
+    </View>
+  );
+}


### PR DESCRIPTION
## 🔷 관련 Jira Ticket ID

[KU-93]

---
## 📌 작업 내용 및 특이사항

- 파티 목록 화면
  - 전체(내가 속한 모든 파티)/MY(내가 생성한 파티) 탭 구분
  - 공용 컴포넌트인 `PartyList`와 `PartyBottomSheet`를 재사용

---
## 📚 참고사항

- 행사 목록 화면 UI 구현
  - `EventList` 컴포넌트에 `isAllEventMode` props를 추가하여 '메인 화면-행사 목록'과 '전체 행사 목록 화면'을 구분

[KU-93]: https://judymoody59.atlassian.net/browse/KU-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ