### PR TITLE
[KU-35] feat: 카카오 로그인-회원가입, 회원 정보 조회 API 연동

### DIFF
--- a/apis/auth/authStorage.ts
+++ b/apis/auth/authStorage.ts
@@ -1,0 +1,15 @@
+import * as SecureStore from "expo-secure-store";
+
+const ACCESS_TOKEN_KEY = "accessToken";
+
+export async function getAccessToken() {
+  return SecureStore.getItemAsync(ACCESS_TOKEN_KEY);
+}
+
+export async function setAccessToken(token: string) {
+  await SecureStore.setItemAsync(ACCESS_TOKEN_KEY, token);
+}
+
+export async function clearAccessToken() {
+  await SecureStore.deleteItemAsync(ACCESS_TOKEN_KEY);
+}

--- a/apis/auth/axiosWithAuthorization.ts
+++ b/apis/auth/axiosWithAuthorization.ts
@@ -1,0 +1,94 @@
+import axios from "axios";
+import { getAccessToken, setAccessToken, clearAccessToken } from "./authStorage";
+
+const baseURL = process.env.EXPO_PUBLIC_API_BASE_URI;
+
+type Listener = () => void;
+let onLogout: Listener | null = null;
+let isLoggingOut = false; // 로그아웃 중복 방지
+
+export function setOnLogoutListener(listener: Listener) {
+  onLogout = listener;
+}
+
+export function clearOnLogoutListener() {
+  onLogout = null;
+}
+
+async function logoutOnce() {
+  if (isLoggingOut) return;
+  isLoggingOut = true;
+
+  try {
+    await clearAccessToken();
+  } finally {
+    onLogout?.();
+  }
+}
+
+export const axiosWithAuthorization = axios.create({
+  baseURL,
+  headers: { "Content-Type": "application/json" },
+  withCredentials: true,
+});
+
+axiosWithAuthorization.interceptors.request.use(
+  async (config) => {
+    const token = await getAccessToken();
+    if (token) {
+      config.headers = config.headers ?? {};
+      config.headers.Authorization = token.startsWith("Bearer ")
+        ? token
+        : `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
+axiosWithAuthorization.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config as
+      | (typeof error.config & { _retry?: boolean })
+      | undefined;
+
+    if (!originalRequest) {
+      return Promise.reject(error);
+    }
+
+    if (error.response?.status === 401 && !originalRequest?._retry) {
+      originalRequest._retry = true;
+
+      const headerAuth =
+        error.response.headers?.authorization ||
+        error.response.headers?.Authorization;
+
+      const bodyAuth =
+        error.response.data?.data?.accessToken ||
+        error.response.data?.accessToken;
+
+      const newAccessToken = headerAuth || bodyAuth;
+
+      if (newAccessToken) {
+        const pureToken = newAccessToken.startsWith("Bearer ")
+          ? newAccessToken.slice(7)
+          : newAccessToken;
+
+        await setAccessToken(pureToken);
+
+        originalRequest.headers = originalRequest.headers ?? {};
+        originalRequest.headers.Authorization = `Bearer ${pureToken}`;
+
+        return axiosWithAuthorization(originalRequest);
+      }
+
+      await logoutOnce();
+      return Promise.reject(error);
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+export default axiosWithAuthorization;

--- a/apis/auth/kakaoAuth.ts
+++ b/apis/auth/kakaoAuth.ts
@@ -1,0 +1,43 @@
+import * as WebBrowser from "expo-web-browser";
+import * as Linking from "expo-linking";
+
+WebBrowser.maybeCompleteAuthSession();
+
+export async function getKakaoCode(): Promise<string> {
+  const clientId = process.env.EXPO_PUBLIC_KAKAO_REST_API_KEY;
+  if (!clientId) throw new Error("Missing EXPO_PUBLIC_KAKAO_REST_API_KEY");
+
+  const base = process.env.EXPO_PUBLIC_API_BASE_URI;
+  if (!base) throw new Error("Missing EXPO_PUBLIC_API_BASE_URI");
+
+  const backendCallback = new URL("/auth/kakao/callback", base).toString();
+
+  const returnTo = Linking.createURL("login");
+
+  const authUrl =
+    "https://kauth.kakao.com/oauth/authorize" +
+    `?client_id=${encodeURIComponent(clientId)}` +
+    `&redirect_uri=${encodeURIComponent(backendCallback)}` +
+    `&response_type=code` +
+    `&state=${encodeURIComponent(returnTo)}`;
+
+  const result = await WebBrowser.openAuthSessionAsync(authUrl, returnTo);
+
+  if (result.type !== "success") {
+    console.warn("[KakaoAuth] cancelled or failed:", result);
+    throw new Error("카카오 로그인에 실패했습니다.");
+  }
+
+  if (!result.url) {
+    throw new Error("카카오 로그인 응답 URL을 받지 못했습니다.");
+  }
+
+  const parsed = Linking.parse(result.url);
+  const code = parsed.queryParams?.code;
+
+  if (!code || typeof code !== "string") {
+    throw new Error("카카오 인증 코드가 전달되지 않았습니다. 다시 시도해주세요.");
+  }
+
+  return code;
+}

--- a/apis/loginApi.ts
+++ b/apis/loginApi.ts
@@ -1,0 +1,47 @@
+import { setAccessToken } from "@/apis/auth/authStorage";
+
+export type SocialLoginResponse = {
+  success: boolean;
+  status: number;
+  data: {
+    accessToken: string;
+  };
+  timestamp: string;
+};
+
+export async function socialLoginWithCode(
+  code: string
+): Promise<SocialLoginResponse> {
+  const base = process.env.EXPO_PUBLIC_API_BASE_URI;
+  if (!base) {
+    console.error("[LoginApi] Missing EXPO_PUBLIC_API_BASE_URI");
+    throw new Error("로그인 환경 설정에 문제가 발생했습니다.");
+  }
+
+  const res = await fetch(`${base}/auth/social-login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include", //쿠키 받기
+    body: JSON.stringify({ code }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error("[LoginApi] social-login failed", {
+      status: res.status
+    });
+    throw new Error("카카오 로그인에 실패했습니다. 잠시 후 다시 시도해주세요.");
+  }
+
+  const json = (await res.json()) as SocialLoginResponse;
+
+  const accessToken = json?.data?.accessToken;
+  if (!accessToken) {
+    console.error("[LoginApi] No accessToken in response", json);
+    throw new Error("로그인 처리 중 오류가 발생했습니다.");
+  }
+
+  await setAccessToken(accessToken);
+
+  return json;
+}

--- a/apis/memberApi.ts
+++ b/apis/memberApi.ts
@@ -1,0 +1,14 @@
+import axiosWithAuthorization from "@/apis/auth/axiosWithAuthorization";
+import type { Member } from "@/types/member";
+
+export type MemberResponse = {
+  success: boolean;
+  status: number;
+  data: Member;
+  timestamp?: string;
+};
+
+export async function getMemberInfo(): Promise<Member> {
+  const res = await axiosWithAuthorization.get<MemberResponse>("/members/me");
+  return res.data.data;
+}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,26 +1,22 @@
 import "../global.css";
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { useFonts } from 'expo-font';
-import { Stack } from 'expo-router';
+import { Stack, router } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { useEffect } from 'react';
 import 'react-native-reanimated';
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "@/lib/queryClient";
-
-import AppNavigator from "@/app/navigation/AppNavigator";
+import { setOnLogoutListener, clearOnLogoutListener } from "@/apis/auth/axiosWithAuthorization";
 
 export {
-  // Catch any errors thrown by the Layout component.
   ErrorBoundary,
 } from 'expo-router';
 
 export const unstable_settings = {
-  // Ensure that reloading on `/modal` keeps a back button present.
   initialRouteName: 'splash', //첫 화면
 };
 
-// Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
@@ -39,7 +35,12 @@ export default function RootLayout() {
     ...FontAwesome.font,
   });
 
-  // Expo Router uses Error Boundaries to catch errors in the navigation tree.
+  //로그아웃 리스너
+  useEffect(() => {
+    setOnLogoutListener(() => router.replace("/login"));
+    return () => clearOnLogoutListener();
+  }, []);
+
   useEffect(() => {
     if (error) throw error;
   }, [error]);

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,4 +1,5 @@
-import { View, ImageBackground, TouchableOpacity, Image } from "react-native";
+import React from "react";
+import { View, ImageBackground, TouchableOpacity, Image, Alert } from "react-native";
 import { useRouter } from "expo-router";
 
 import LoginTitle from "../components/titles/LoginTitle";
@@ -8,12 +9,36 @@ const BG_IMG = require("../assets/images/login-background.png");
 const LOGO3 = require("../assets/images/katchup-logo3.png"); 
 const KAKAO_BTN = require("../assets/images/kakao-login-btn.png");
 
+import { getKakaoCode } from "@/apis/auth/kakaoAuth";
+import { socialLoginWithCode } from "@/apis/loginApi";
+import { getMemberInfo } from "@/apis/memberApi";
+
 export default function LoginScreen() {
   const router = useRouter();
 
-  const moveToSignUp = () => {
-    router.push("/signup/nickname");
-  }
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const handleKakaoLogin = async () => {
+    if (isLoading) return;
+    setIsLoading(true);
+
+    try {
+      const code = await getKakaoCode();
+      if (!code) throw new Error("인가 코드(code)를 받지 못했습니다.");
+
+      await socialLoginWithCode(code);
+      Alert.alert("로그인 성공", "카카오 로그인이 완료되었습니다!");
+
+      const me = await getMemberInfo();
+      const needSignup = !me?.nickname || !me?.style;
+      router.replace(needSignup ? "/signup/nickname" : "/mainTabs");
+    } catch (e: any) {
+      console.error("[KakaoLogin] error:", e);
+      Alert.alert("로그인 실패", "카카오 로그인에 실패했습니다.\n잠시 후 다시 시도해주세요.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
   return (
       <ImageBackground
@@ -35,8 +60,9 @@ export default function LoginScreen() {
 
         <View className="px-8 mb-10">
           <TouchableOpacity 
-            onPress={moveToSignUp}
+            onPress={handleKakaoLogin}
             activeOpacity={0.8}
+            disabled={isLoading}
             hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
             accessibilityLabel="카카오 로그인"
             accessibilityRole="button"


### PR DESCRIPTION
## 🔷 관련 Jira Ticket ID

[KU-35]

---
## 📌 작업 내용 및 특이사항

- **카카오 로그인-회원가입 API 연동**
  - `expo-web-browser`, `expo-linking` 기반으로 카카오 OAuth 인가 코드(code) 획득 후, 로그인-회원가입(`/auth/social-login`) API를 호출하여 accessToken 발급
  - **axiosWithAuthorization:** 인증이 필요한 API 요청을 위해 axios 공통 인스턴스에 Authorization 인터셉터 구현
  - accessToken 자동 첨부 및 accessToken 만료 시 서버 응답을 통해 재발급 처리
  - refreshToken 만료 시 자동 로그아웃 및 로그인 화면으로 이동

- **회원 정보 조회 API 연동**
  - 로그인 후 회원 정보 조회(`/members/me`) 결과에 따른 화면 분기 처리
    - nickname 또는 style 정보가 없는 경우: 온보딩 화면으로 이동
    - 회원 정보가 모두 존재하는 경우: 메인 화면으로 이동

---
## 📚 참고사항

- 발급된 accessToken은 `expo-secure-store`으로 로컬 저장 및 관리
- 로그아웃 처리 중복 실행 방지 로직 구현(apis/auth/axiosWithAuthorization.ts)

[KU-35]: https://judymoody59.atlassian.net/browse/KU-35?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ