### PR TITLE
[KU-116] fix: 행사 목록 API 수정

### DIFF
--- a/apis/eventApi.ts
+++ b/apis/eventApi.ts
@@ -27,10 +27,15 @@ export type ApiResponse<T> = {
   timestamp: string;
 };
 
+export type EventsData = {
+  events: SliceResponse<EventItem>;
+  totalCount: number;
+};
+
 export async function getEventList(params: GetEventsParams = {}) {
   const { lastEventId, size = EVENTS_SLICE_SIZE } = params;
 
-  const res = await axiosWithAuthorization.get<ApiResponse<SliceResponse<EventItem>>>(
+  const res = await axiosWithAuthorization.get<ApiResponse<EventsData>>(
     "/events",
     {
       params: {
@@ -52,7 +57,7 @@ export type SearchEventsParams = {
 export async function searchEventList(params: SearchEventsParams) {
   const { eventName, lastEventId, size = EVENTS_SLICE_SIZE } = params;
 
-  const res = await axiosWithAuthorization.get<ApiResponse<SliceResponse<EventItem>>>(
+  const res = await axiosWithAuthorization.get<ApiResponse<EventsData>>(
     "/events/search",
     {
       params: {

--- a/app/navigation/CreatePartyStack.tsx
+++ b/app/navigation/CreatePartyStack.tsx
@@ -5,7 +5,7 @@ import CreatePartyScreen from "../main-screens/create-p";
 export type CreatePartyStackParamList = {
   ChooseEventScreen: undefined;
   CreatePartyScreen: {
-    eventId: string;
+    eventId: number;
     eventName: string;
     facilityName: string;
     startDate: string;

--- a/app/navigation/MainStack.tsx
+++ b/app/navigation/MainStack.tsx
@@ -5,7 +5,7 @@ import MainPartyScreen from "../main-screens/main-p";
 export type MainStackParamList = {
   MainEventScreen: undefined;
   MainPartyScreen: {
-    eventId: string;
+    eventId: number;
     eventName: string;
     facilityName: string;
     startDate: string;

--- a/components/inputs/CreatePartyInput.tsx
+++ b/components/inputs/CreatePartyInput.tsx
@@ -18,7 +18,7 @@ import CreatePartyButton from "../buttons/CreatePartyButton";
 import KakaoPlaceSearchModal from "../modals/KakaoPlaceSearchModal";
 
 interface CreatePartyInputProps {
-  eventId: string;
+  eventId: number;
   facilityName: string;
   startDate: string;
   endDate: string;

--- a/components/lists/EventList.tsx
+++ b/components/lists/EventList.tsx
@@ -28,6 +28,7 @@ export default function EventList({
 
   const navigation = useNavigation<NavigationProp<RootTabParamList>>();
   const [eventList, setEventList] = React.useState<EventItem[]>([]);
+  const [totalCount, setTotalCount] = React.useState<number>(0);
   const [isLoading, setIsLoading] = React.useState(false);
   const [isFetchingMore, setIsFetchingMore] = React.useState(false);
 
@@ -62,9 +63,10 @@ export default function EventList({
 
         if (!mounted) return;
 
-        const content = data.content ?? [];
+        const { content = [], last } = data.events;
         setEventList(content);
-        setHasMore(!data.last);
+        setHasMore(!last);
+        setTotalCount(data.totalCount);
 
         if (content.length > 0) {
           const nextCursor = content[content.length - 1].id;
@@ -103,15 +105,14 @@ export default function EventList({
         ? await searchEventList({ eventName: keyword, lastEventId: cursor })
         : await getEventList({ lastEventId: cursor });
 
-      const content = data.content ?? [];
+      const content = data.events.content ?? [];
 
       setEventList((prev) => {
         const prevIds = new Set(prev.map((v) => v.id));
-        const merged = [...prev, ...content.filter((v) => !prevIds.has(v.id))];
-        return merged;
+        return [...prev, ...content.filter((v) => !prevIds.has(v.id))];
       });
 
-      setHasMore(!data.last);
+      setHasMore(!data.events.last);
 
       if (content.length > 0) {
         const nextCursor = content[content.length - 1].id;
@@ -127,7 +128,7 @@ export default function EventList({
   const title = isAllEventMode
     ? "모든 행사 보기"
     : isSearched
-    ? `검색 결과 (${eventList.length})`
+    ? `검색 결과 (${totalCount})`
     : "실시간 인기 있는 행사";
 
   const shouldShowEmpty = isSearched && !isLoading && eventList.length === 0;
@@ -143,7 +144,7 @@ export default function EventList({
         if (isAllEventMode) return;
 
         const payload = {
-          eventId: item.eventId,
+          eventId: item.id,
           eventName: item.eventName,
           facilityName: item.facilityName,
           startDate: item.startDate,

--- a/mocks/events.ts
+++ b/mocks/events.ts
@@ -3,7 +3,6 @@ import type { EventItem } from "@/types/event";
 export const events: EventItem[] = [
   {
     id: 3306,
-    eventId: "PF123456",
     eventName: "BLACKPINK WORLD TOUR [BORN PINK] FINALE IN SEOUL",
     startDate: "2025-08-01",
     endDate: "2025-08-05",
@@ -15,7 +14,6 @@ export const events: EventItem[] = [
   },
   {
     id: 3307,
-    eventId: "PF987654",
     eventName: "BLACKPINK WORLD TOUR [BORN PINK] FINALE IN SEOUL",
     startDate: "2025-09-15",
     endDate: "2025-10-30",
@@ -27,7 +25,6 @@ export const events: EventItem[] = [
   },
   {
     id: 3308,
-    eventId: "PF654321",
     eventName: "BLACKPINK WORLD TOUR [BORN PINK] FINALE IN SEOUL",
     startDate: "2025-11-01",
     endDate: "2025-12-15",
@@ -39,7 +36,6 @@ export const events: EventItem[] = [
   },
   {
     id: 3309,
-    eventId: "PF123406",
     eventName: "BLACKPINK WORLD TOUR [BORN PINK] FINALE IN SEOUL",
     startDate: "2025-08-01",
     endDate: "2025-09-07",
@@ -51,7 +47,6 @@ export const events: EventItem[] = [
   },
   {
     id: 3310,
-    eventId: "PF980654",
     eventName: "BLACKPINK WORLD TOUR [BORN PINK] FINALE IN SEOUL",
     startDate: "2025-09-15",
     endDate: "2025-10-30",
@@ -63,7 +58,6 @@ export const events: EventItem[] = [
   },
   {
     id: 3311,
-    eventId: "PF650321",
     eventName: "BLACKPINK WORLD TOUR [BORN PINK] FINALE IN SEOUL",
     startDate: "2025-11-01",
     endDate: "2025-12-15",
@@ -75,7 +69,6 @@ export const events: EventItem[] = [
   },
   {
     id: 3312,
-    eventId: "PF193456",
     eventName: "BLACKPINK WORLD TOUR [BORN PINK] FINALE IN SEOUL",
     startDate: "2025-08-01",
     endDate: "2025-09-07",
@@ -87,7 +80,6 @@ export const events: EventItem[] = [
   },
   {
     id: 3313,
-    eventId: "PF987694",
     eventName: "BLACKPINK WORLD TOUR [BORN PINK] FINALE IN SEOUL",
     startDate: "2025-09-15",
     endDate: "2025-10-30",
@@ -99,7 +91,6 @@ export const events: EventItem[] = [
   },
   {
     id: 3314,
-    eventId: "PF654921",
     eventName: "BLACKPINK WORLD TOUR [BORN PINK] FINALE IN SEOUL",
     startDate: "2025-11-01",
     endDate: "2025-12-15",

--- a/types/event.ts
+++ b/types/event.ts
@@ -2,7 +2,6 @@ export type EventStatus = "공연중" | "공연예정" | "종료" | string;
 
 export interface EventItem {
   id: number;
-  eventId: string;
   eventName: string;
   startDate: string;
   endDate: string;


### PR DESCRIPTION
## 🔷 관련 Jira Ticket ID

[KU-116]

---
## 📌 작업 내용 및 특이사항

- 변경된 행사 목록 API 응답 구조 반영
- **EventItem 타입에서 `eventId(string)` 필드 제거**
  - 행사 목록 slice pagination에서 사용하는 `lastEventId`는 `id(number)`를 기준으로 동작
  - 파티 생성 시 필요한 행사 식별자 `eventId(number)`는 EventItem 의 `id(number)`와 같음
---
## 📚 참고사항

-

[KU-116]: https://judymoody59.atlassian.net/browse/KU-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ