### PR TITLE
[KU-117] feat: 회원 정보 API 연동

### DIFF
--- a/apis/memberApi.ts
+++ b/apis/memberApi.ts
@@ -12,3 +12,11 @@ export async function getMyMemberInfo(): Promise<Member> {
   const res = await axiosWithAuthorization.get<MemberResponse>("/members/me");
   return res.data.data;
 }
+
+export async function getOtherMemberInfo(memberId: number): Promise<Member> {
+  const res = await axiosWithAuthorization.get<MemberResponse>(
+    `/members/${memberId}`
+  );
+  return res.data.data;
+}
+

--- a/app/main-screens/my.tsx
+++ b/app/main-screens/my.tsx
@@ -1,14 +1,57 @@
 import React from "react";
-import { ScrollView } from "react-native";
+import { ScrollView, View, Text } from "react-native";
 import MyProfileSection from "@/components/sections/MyProfileSection";
 import MyStyleSection from "@/components/sections/MyStyleSection";
+import LoadingOverlay from "@/components/loadings/LoadingOverlay";
+
+import { getMyMemberInfo } from "@/apis/memberApi";
+import type { Member } from "@/types/member";
 
 export default function MyScreen(){
+    const [member, setMember] = React.useState<Member | null>(null);
+    const [loading, setLoading] = React.useState(true);
+    const [error, setError] = React.useState<string | null>(null);
+
+    React.useEffect(() => {
+    let mounted = true;
+
+    (async () => {
+      try {
+        setLoading(true);
+        const me = await getMyMemberInfo();
+        console.log("[MyScreen] getMyMemberInfo response:", me);
+        
+        if (!mounted) return;
+        setMember(me);
+      } catch (e) {
+        if (!mounted) return;
+        setError("회원 정보를 불러오지 못했어요.");
+      } finally {
+        if (!mounted) return;
+        setLoading(false);
+      }
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (error || !member) {
+    return (
+      <View className="flex-1 items-center justify-center bg-white">
+        <Text>{error ?? "회원 정보가 없습니다."}</Text>
+      </View>
+    );
+  }
 
     return (
-        <ScrollView className="flex-1 bg-white" showsVerticalScrollIndicator={false}>
-            <MyProfileSection />
-            <MyStyleSection />
-        </ScrollView>
+        <>
+            <ScrollView className="flex-1 bg-white" showsVerticalScrollIndicator={false}>
+                <MyProfileSection member={member} />
+                <MyStyleSection member={member} />
+            </ScrollView>
+            <LoadingOverlay visible={loading} />
+        </>
     );
 }

--- a/components/sections/MyProfileSection.tsx
+++ b/components/sections/MyProfileSection.tsx
@@ -4,9 +4,13 @@ import { colors } from "@/constants/colors";
 import { fonts } from "@/constants/fonts";
 
 import { profileImages } from "@/utils/profileImgMapper";
-import { member } from "@/mocks/member";
+import type { Member } from "@/types/member";
 
-export default function MyProfileSection() {
+type MyProfileSectionProps = {
+  member: Member;
+};
+
+export default function MyProfileSection({ member }: MyProfileSectionProps) {
   return (
     <View>
       <View className="flex-row items-center px-6 pt-10">

--- a/components/sections/MyStyleSection.tsx
+++ b/components/sections/MyStyleSection.tsx
@@ -4,10 +4,14 @@ import { colors, styleColors } from "@/constants/colors";
 import { fonts } from "@/constants/fonts";
 import StyleRow from "./StyleRow";
 
-import { member } from "@/mocks/member";
+import type { Member } from "@/types/member";
 
-export default function MyStyleSection() {
-  const { style } = member;
+type MyStyleSectionProps = {
+  member: Member;
+};
+
+export default function MyStyleSection({ member }: MyStyleSectionProps) {
+  const style = member.style;
 
   if (!style) return null;
 
@@ -32,8 +36,8 @@ export default function MyStyleSection() {
       <StyleRow
         leftLabel="외향형"
         rightLabel="내향형"
-        leftValue={style.escore}
-        rightValue={style.iscore}
+        leftValue={style.eScore}
+        rightValue={style.iScore}
         barColor={styleColors.style1}
         icon="people-outline"
       />

--- a/components/sections/StyleRow.tsx
+++ b/components/sections/StyleRow.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { View, Text, LayoutChangeEvent } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import { colors } from "@/constants/colors";
+import { colors, styleColors } from "@/constants/colors";
 import { fonts } from "@/constants/fonts";
 
 type StyleRowProps = {
@@ -14,8 +14,27 @@ type StyleRowProps = {
   isLast?: boolean;
 };
 
-const ICON_SIZE = 44;
-const TRACK_HEIGHT = 22;
+const STYLE_ROW_UI = {
+  ICON_SIZE: 44,
+  TRACK_HEIGHT: 22,
+  MIN_FILL_PX: 5,
+  TRACK_BG: styleColors.styleBg,
+  ICON_BORDER: 4,
+} as const;
+
+const clampPct = (v: number) => Math.max(0, Math.min(100, v));
+
+const SCALE_EXP = 0.75;
+const scaledRatio = (pct: number) =>
+  Math.pow(clampPct(pct) / 100, SCALE_EXP);
+
+const calcFillPx = (half: number, value: number) => {
+  const pct = clampPct(value);
+  if (pct <= 0) return 0;
+
+  const raw = half * scaledRatio(pct);
+  return Math.max(STYLE_ROW_UI.MIN_FILL_PX, raw);
+};
 
 export default function StyleRow({
   leftLabel,
@@ -28,17 +47,21 @@ export default function StyleRow({
 }: StyleRowProps) {
   const [trackWidth, setTrackWidth] = React.useState(0);
 
-  const onTrackLayout = (e: LayoutChangeEvent) => {
+  const onTrackLayout = React.useCallback((e: LayoutChangeEvent) => {
     const w = e.nativeEvent.layout.width;
     setTrackWidth((prev) => (prev === w ? prev : w));
-  };
+  }, []);
 
-  const half = trackWidth / 2;
+  const { half, leftFillPx, rightFillPx, iconLeftPx } = React.useMemo(() => {
+    const half = trackWidth / 2;
 
-  const leftFillPx = half * (Math.max(0, Math.min(100, leftValue)) / 100);
-  const rightFillPx = half * (Math.max(0, Math.min(100, rightValue)) / 100);
-
-  const iconLeftPx = half - ICON_SIZE / 2;
+    return {
+      half,
+      leftFillPx: calcFillPx(half, leftValue),
+      rightFillPx: calcFillPx(half, rightValue),
+      iconLeftPx: half - STYLE_ROW_UI.ICON_SIZE / 2,
+    };
+  }, [trackWidth, leftValue, rightValue]);
 
   return (
     <View className={isLast ? "mb-4" : "mb-8"}>
@@ -50,13 +73,12 @@ export default function StyleRow({
           {rightLabel} {rightValue}%
         </Text>
       </View>
-
       <View
         onLayout={onTrackLayout}
         style={{
-          height: TRACK_HEIGHT,
-          borderRadius: TRACK_HEIGHT / 2,
-          backgroundColor: "#D9D9D9",
+          height: STYLE_ROW_UI.TRACK_HEIGHT,
+          borderRadius: STYLE_ROW_UI.TRACK_HEIGHT / 2,
+          backgroundColor: STYLE_ROW_UI.TRACK_BG,
           overflow: "visible",
           position: "relative",
         }}
@@ -66,39 +88,37 @@ export default function StyleRow({
             position: "absolute",
             right: half,
             top: 0,
-            height: TRACK_HEIGHT,
+            height: STYLE_ROW_UI.TRACK_HEIGHT,
             width: leftFillPx,
             backgroundColor: barColor,
-            borderTopLeftRadius: TRACK_HEIGHT / 2,
-            borderBottomLeftRadius: TRACK_HEIGHT / 2,
+            borderTopLeftRadius: STYLE_ROW_UI.TRACK_HEIGHT / 2,
+            borderBottomLeftRadius: STYLE_ROW_UI.TRACK_HEIGHT / 2,
           }}
         />
-
         <View
           style={{
             position: "absolute",
             left: half,
             top: 0,
-            height: TRACK_HEIGHT,
+            height: STYLE_ROW_UI.TRACK_HEIGHT,
             width: rightFillPx,
             backgroundColor: barColor,
-            borderTopRightRadius: TRACK_HEIGHT / 2,
-            borderBottomRightRadius: TRACK_HEIGHT / 2,
+            borderTopRightRadius: STYLE_ROW_UI.TRACK_HEIGHT / 2,
+            borderBottomRightRadius: STYLE_ROW_UI.TRACK_HEIGHT / 2,
           }}
         />
-
         <View
           style={{
             position: "absolute",
-            top: -(ICON_SIZE - TRACK_HEIGHT) / 2,
+            top: -(STYLE_ROW_UI.ICON_SIZE - STYLE_ROW_UI.TRACK_HEIGHT) / 2,
             left: iconLeftPx,
-            width: ICON_SIZE,
-            height: ICON_SIZE,
-            borderRadius: ICON_SIZE / 2,
+            width: STYLE_ROW_UI.ICON_SIZE,
+            height: STYLE_ROW_UI.ICON_SIZE,
+            borderRadius: STYLE_ROW_UI.ICON_SIZE / 2,
             backgroundColor: colors.white,
             alignItems: "center",
             justifyContent: "center",
-            borderWidth: 4,
+            borderWidth: STYLE_ROW_UI.ICON_BORDER,
             borderColor: barColor,
           }}
         >

--- a/constants/colors.ts
+++ b/constants/colors.ts
@@ -22,6 +22,7 @@ export const styleColors = {
   style2: "#FEC611",
   style3: "#EF6368",
   style4: "#F8937A",
+  styleBg: "#D9D9D9",
   
 } as const;
 

--- a/mocks/member.ts
+++ b/mocks/member.ts
@@ -13,7 +13,7 @@ export const member: Member = {
     immerseScore: 90,
     frontScore: 60,
     backScore: 40,
-    iscore: 80,
-    escore: 50,
+    iScore: 80,
+    eScore: 50,
   },
 }

--- a/types/member.ts
+++ b/types/member.ts
@@ -14,6 +14,6 @@ export type MemberStyle = {
   immerseScore: number;
   frontScore: number;
   backScore: number;
-  iscore: number;
-  escore: number;
+  iScore: number;
+  eScore: number;
 };


### PR DESCRIPTION
## 🔷 관련 Jira Ticket ID

[KU-117]

---
## 📌 작업 내용 및 특이사항

- **마이페이지 회원 정보 API 연동**
  - `MyProfileSection`, `MyStyleSection` 컴포넌트에 적용
  <img width="500" height="700" alt="image" src="https://github.com/user-attachments/assets/447164d8-a143-458a-b32b-abbd284721d0" />

- **타 회원 프로필 조회 API 함수 구현(getOtherMemberInfo)**
  - UI 적용은 추후 진행 예정
---
## 📚 참고사항

- 마이페이지 성향 지표 Bar 채움 비율 조정

[KU-117]: https://judymoody59.atlassian.net/browse/KU-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ