### PR TITLE
[KU-118] feat: 파티 API 연동

### DIFF
--- a/apis/eventApi.ts
+++ b/apis/eventApi.ts
@@ -1,30 +1,12 @@
 import axiosWithAuthorization from "./auth/axiosWithAuthorization";
 import type { EventItem } from "@/types/event";
+import type { SliceResponse, ApiResponse } from "@/types/response";
 
 export const EVENTS_SLICE_SIZE = 6;
 
 export type GetEventsParams = {
   lastEventId?: number;
   size?: number;
-};
-
-export type SliceResponse<T> = {
-  content: T[];
-  last: boolean;
-  first: boolean;
-  empty: boolean;
-  number: number;
-  size: number;
-  numberOfElements: number;
-  pageable?: unknown;
-  sort?: unknown;
-};
-
-export type ApiResponse<T> = {
-  data: T;
-  status: number;
-  success: boolean;
-  timestamp: string;
 };
 
 export type EventsData = {

--- a/apis/kakaoApi.ts
+++ b/apis/kakaoApi.ts
@@ -1,4 +1,4 @@
-import type { KakaoPlace } from "@/types/kakao-place";
+import type { KakaoPlace } from "@/types/place";
 
 const KAKAO_REST_API_KEY = (process.env.EXPO_PUBLIC_KAKAO_REST_API_KEY ?? "").trim();
 

--- a/apis/partyApi.ts
+++ b/apis/partyApi.ts
@@ -68,7 +68,27 @@ export async function togglePartyLike(
   const res = await axiosWithAuthorization.post<ApiResponse<null>>(
     `/parties/${partyId}/like`
   );
-
-  console.log("[API] 파티 찜 토글 응답:", res.data);
   return res.data;
+}
+
+export type GetLikedPartiesParams = {
+  lastLikeId?: number;
+  size?: number;
+};
+
+export async function getLikedPartyList(
+  params: GetLikedPartiesParams = {}
+): Promise<SliceResponse<PartyItem>> {
+  const { lastLikeId, size = PARTIES_SLICE_SIZE } = params;
+
+  const res = await axiosWithAuthorization.get<
+    ApiResponse<SliceResponse<PartyItem>>
+  >("/parties/list/liked", {
+    params: {
+      ...(lastLikeId != null ? { lastLikeId } : {}),
+      size,
+    },
+  });
+
+  return res.data.data;
 }

--- a/apis/partyApi.ts
+++ b/apis/partyApi.ts
@@ -60,5 +60,15 @@ export async function getPartyList(
   return res.data.data;
 }
 
+/* -------------------- 관심 파티 -------------------- */
 
+export async function togglePartyLike(
+  partyId: number
+): Promise<ApiResponse<null>> {
+  const res = await axiosWithAuthorization.post<ApiResponse<null>>(
+    `/parties/${partyId}/like`
+  );
 
+  console.log("[API] 파티 찜 토글 응답:", res.data);
+  return res.data;
+}

--- a/apis/partyApi.ts
+++ b/apis/partyApi.ts
@@ -29,3 +29,36 @@ export async function createParty(body: CreatePartyRequest): Promise<ApiResponse
   return res.data;
 }
 
+/* -------------------- 파티 목록 조회 -------------------- */
+
+// host : 내가 생성한 파티 목록 조회
+// participant : 내가 참여한 파티 조회
+export type PartyListType = "host" | "participant";
+
+export const PARTIES_SLICE_SIZE = 6;
+
+export type GetPartiesParams = {
+  lastParticipantId?: number;
+  size?: number;
+};
+
+export async function getPartyList(
+  type: PartyListType,
+  params: GetPartiesParams = {}
+): Promise<SliceResponse<PartyItem>> {
+  const { lastParticipantId, size = PARTIES_SLICE_SIZE } = params;
+
+  const res = await axiosWithAuthorization.get<
+    ApiResponse<SliceResponse<PartyItem>>
+  >(`/parties/list/${type}`, {
+    params: {
+      ...(lastParticipantId != null ? { lastParticipantId } : {}),
+      size,
+    },
+  });
+
+  return res.data.data;
+}
+
+
+

--- a/apis/partyApi.ts
+++ b/apis/partyApi.ts
@@ -1,0 +1,31 @@
+import axiosWithAuthorization from "./auth/axiosWithAuthorization";
+import type { PartyItem } from "@/types/party";
+import type { KakaoPlace } from "@/types/place";
+import type { PartyType, RouteType, GenderType } from "@/types/party";
+import type { SliceResponse, ApiResponse } from "@/types/response";
+import axios from "axios";
+
+export type CreatePartyRequest = {
+  eventId: number;
+  type: PartyType;
+  routeType: RouteType | null;
+  gender: GenderType;
+  capacity: number;
+  maxBirthYear: number | null;
+  minBirthYear: number | null;
+  startAt: string;
+  endAt: string | null;
+  description: string;
+  departure?: KakaoPlace;
+  arrival: KakaoPlace;
+};
+
+
+export async function createParty(body: CreatePartyRequest): Promise<ApiResponse<null>> {
+  const res = await axiosWithAuthorization.post<ApiResponse<null>>(
+    "/parties/create",
+    body
+  );
+  return res.data;
+}
+

--- a/apis/partyApi.ts
+++ b/apis/partyApi.ts
@@ -99,3 +99,28 @@ export async function getLikedPartyList(
 
   return res.data.data;
 }
+
+/* -------------------- 파티 확정 + 오픈채팅방 링크 추가 -------------------- */
+
+export type ConfirmPartyRequest = {
+  chatUrl: string;
+};
+
+export async function confirmParty(
+  partyId: number,
+  body: ConfirmPartyRequest
+): Promise<ApiResponse<null>> {
+  try {
+    const res = await axiosWithAuthorization.patch<ApiResponse<null>>(
+      `/parties/${partyId}`,
+      body
+    );
+    return res.data;
+  } catch (e: unknown) {
+    if (axios.isAxiosError(e)) {
+      console.warn("[confirmParty] status:", e.response?.status);
+      console.warn("[confirmParty] data:", e.response?.data);
+    }
+    throw e;
+  }
+}

--- a/apis/partyApi.ts
+++ b/apis/partyApi.ts
@@ -115,12 +115,38 @@ export async function confirmParty(
       `/parties/${partyId}`,
       body
     );
-    return res.data;
+
+    const data = res.data;
+
+    if (data?.success === false) {
+      const msg =
+        (data as any)?.data?.message ||
+        (data as any)?.message ||
+        "파티 확정에 실패했어요. 다시 시도해주세요.";
+
+      throw new Error(msg);
+    }
+
+    return data;
   } catch (e: unknown) {
+    if (e instanceof Error) {
+      console.warn("[confirmParty] Error:", e.message);
+      throw e;
+    }
+
     if (axios.isAxiosError(e)) {
       console.warn("[confirmParty] status:", e.response?.status);
       console.warn("[confirmParty] data:", e.response?.data);
+
+      const serverMsg =
+        (e.response?.data as any)?.data?.message ||
+        (e.response?.data as any)?.message;
+
+      if (typeof serverMsg === "string" && serverMsg.trim()) {
+        throw new Error(serverMsg);
+      }
     }
+
     throw e;
   }
 }

--- a/apis/partyApi.ts
+++ b/apis/partyApi.ts
@@ -29,6 +29,13 @@ export async function createParty(body: CreatePartyRequest): Promise<ApiResponse
   return res.data;
 }
 
+export async function getPartyDetail(partyId: number): Promise<PartyItem> {
+  const res = await axiosWithAuthorization.get<ApiResponse<PartyItem>>(
+    `/parties/${partyId}`
+  );
+  return res.data.data;
+}
+
 /* -------------------- 파티 목록 조회 -------------------- */
 
 // host : 내가 생성한 파티 목록 조회

--- a/app/main-screens/liked-party.tsx
+++ b/app/main-screens/liked-party.tsx
@@ -24,9 +24,6 @@ export default function LikedPartyListScreen(){
   const [selectedPartyId, setSelectedPartyId] = useState<number | null>(null);
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
     
-  const selectedParty =
-    partyData.find((party) => party.partyId === selectedPartyId) ?? null;
-
   const isInitialLoading = isFetching && partyData.length === 0;
 
   const loadLikedParties = async (mode: "RESET" | "MORE") => {
@@ -68,6 +65,11 @@ export default function LikedPartyListScreen(){
   );
 
   const handleToggleLike = async (partyId: number) => {
+    if (selectedPartyId === partyId) {
+      setIsBottomSheetOpen(false);
+      setSelectedPartyId(null);
+    }
+
     const backup = partyData;
     setPartyData((prev) => prev.filter((p) => p.partyId !== partyId));
 
@@ -123,8 +125,11 @@ export default function LikedPartyListScreen(){
 
       <PartyBottomSheet
           isVisible={isBottomSheetOpen}
-          party={selectedParty}
-          onClose={() => { setIsBottomSheetOpen(false);}}
+          partyId={selectedPartyId}
+          onClose={() => {
+            setIsBottomSheetOpen(false);
+            setSelectedPartyId(null);
+          }}
           onToggleLike={handleToggleLike}
       />
       {toastMessage && <ShortToast message={toastMessage} />}

--- a/app/main-screens/liked-party.tsx
+++ b/app/main-screens/liked-party.tsx
@@ -1,29 +1,84 @@
-import React, { useState } from "react";
-import { TouchableOpacity, ScrollView } from "react-native";
+import React, { useState, useCallback } from "react";
+import { useFocusEffect } from "@react-navigation/native";
+import { TouchableOpacity, View, FlatList } from "react-native";
 import PartyList from "@/components/lists/PartyList";
 import PartyBottomSheet from "@/components/sections/PartyBottomSheet";
 
 import type { PartyItem } from "@/types/party";
-import { parties } from "@/mocks/parties";
 import { colors } from "@/constants/colors";
 import PartyListTitle from "@/components/titles/PartyListTitle";
 import LikedPartyBar from "@/components/bars/LikedPartyBar";
+import ShortToast from "@/components/toasts/ShortToast";
+import LoadingOverlay from "@/components/loadings/LoadingOverlay";
+
+import { getLikedPartyList, togglePartyLike } from "@/apis/partyApi";
 
 export default function LikedPartyListScreen(){
-  const [partyData, setPartyData] = useState(parties);
-  
+  const [partyData, setPartyData] = useState<PartyItem[]>([]);
+  const [cursor, setCursor] = useState<number | undefined>(undefined);
+  const [hasMore, setHasMore] = useState(true);
+  const [isFetching, setIsFetching] = useState(false);
+
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+
   const [selectedPartyId, setSelectedPartyId] = useState<number | null>(null);
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
     
   const selectedParty =
     partyData.find((party) => party.partyId === selectedPartyId) ?? null;
-  
-  const handleToggleLike = (id: number) => {
-    setPartyData(prev =>
-      prev.map(item =>
-        item.partyId === id ? { ...item, isLiked: !item.isLiked } : item
-      )
-    );
+
+  const isInitialLoading = isFetching && partyData.length === 0;
+
+  const loadLikedParties = async (mode: "RESET" | "MORE") => {
+    if (isFetching) return;
+    if (mode === "MORE" && !hasMore) return;
+
+    setIsFetching(true);
+    try {
+      const lastLikeId = mode === "RESET" ? undefined : cursor;
+
+      const res = await getLikedPartyList({ lastLikeId });
+      const newItems = res.content ?? [];
+
+      setPartyData((prev) => (mode === "RESET" ? newItems : [...prev, ...newItems]));
+      setHasMore(!res.last);
+
+      const lastItem = newItems[newItems.length - 1];
+      if (lastItem) setCursor(lastItem.partyId);
+    } catch (e) {
+      console.warn("관심 파티 목록 조회 실패:", e);
+      setToastMessage("관심 목록을 불러오지 못했어요.");
+      setTimeout(() => setToastMessage(null), 1500);
+    } finally {
+      setIsFetching(false);
+    }
+  };
+
+  useFocusEffect(
+    useCallback(() => {
+      setIsBottomSheetOpen(false);
+      setSelectedPartyId(null);
+
+      setCursor(undefined);
+      setHasMore(true);
+      setPartyData([]);
+
+      loadLikedParties("RESET");
+    }, [])
+  );
+
+  const handleToggleLike = async (partyId: number) => {
+    const backup = partyData;
+    setPartyData((prev) => prev.filter((p) => p.partyId !== partyId));
+
+    try {
+      await togglePartyLike(partyId);
+    } catch (e) {
+      console.warn("찜 해제 실패:", e);
+      setPartyData(backup);
+      setToastMessage("찜 처리에 실패했어요.");
+      setTimeout(() => setToastMessage(null), 1500);
+    }
   };
     
   const handleSelectParty = (party: PartyItem) => {
@@ -38,21 +93,32 @@ export default function LikedPartyListScreen(){
   return (
     <>
       <TouchableOpacity 
-          activeOpacity={1} 
-          style={{ flex: 1 }} 
-          onPress={clearSelection}
+        activeOpacity={1} 
+        style={{ flex: 1 }} 
+        onPress={clearSelection}
       >
-        <ScrollView className="flex-1" style={{ backgroundColor: colors.white }}>
-          <PartyListTitle title="관심 목록"/>
-          <LikedPartyBar/>
-          <PartyList 
-              partyData={partyData} 
-              countPartyNum={10}
-              onToggleLike={handleToggleLike}
-              onSelectParty={handleSelectParty}
-              selectedPartyId={selectedPartyId}
+        <View style={{ flex: 1, backgroundColor: colors.white }}>
+          <PartyListTitle title="관심 목록" />
+            <LikedPartyBar />
+          <FlatList
+            data={[{ key: "only" }]}
+            keyExtractor={(item) => item.key}
+            renderItem={() => (
+              <PartyList
+                partyData={partyData}
+                countPartyNum={partyData.length}
+                onToggleLike={handleToggleLike}
+                onSelectParty={handleSelectParty}
+                selectedPartyId={selectedPartyId}
+                isLoading={isInitialLoading}
+              />
+            )}
+            onEndReachedThreshold={0.6}
+            onEndReached={() => loadLikedParties("MORE")}
+            contentContainerStyle={{ paddingTop: 16, paddingBottom: 60 }}
+            showsVerticalScrollIndicator={false}
           />
-        </ScrollView>
+        </View>
       </TouchableOpacity>
 
       <PartyBottomSheet
@@ -61,6 +127,9 @@ export default function LikedPartyListScreen(){
           onClose={() => { setIsBottomSheetOpen(false);}}
           onToggleLike={handleToggleLike}
       />
+      {toastMessage && <ShortToast message={toastMessage} />}
+
+      <LoadingOverlay visible={isInitialLoading} />
     </>
   );
 }

--- a/app/main-screens/liked-party.tsx
+++ b/app/main-screens/liked-party.tsx
@@ -78,7 +78,7 @@ export default function LikedPartyListScreen(){
     } catch (e) {
       console.warn("찜 해제 실패:", e);
       setPartyData(backup);
-      setToastMessage("찜 처리에 실패했어요.");
+      setToastMessage("찜 해제 처리에 실패했어요.");
       setTimeout(() => setToastMessage(null), 1500);
     }
   };

--- a/app/main-screens/my.tsx
+++ b/app/main-screens/my.tsx
@@ -19,8 +19,6 @@ export default function MyScreen(){
       try {
         setLoading(true);
         const me = await getMyMemberInfo();
-        console.log("[MyScreen] getMyMemberInfo response:", me);
-        
         if (!mounted) return;
         setMember(me);
       } catch (e) {

--- a/app/main-screens/party-list.tsx
+++ b/app/main-screens/party-list.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from "react";
+import React, { useState, useMemo, useEffect, useRef } from "react";
 import { View, TouchableOpacity, FlatList } from "react-native";
 import PartyList from "@/components/lists/PartyList";
 import PartyBottomSheet from "@/components/sections/PartyBottomSheet";
@@ -30,7 +30,7 @@ export default function PartyListScreen(){
     MY: false,
   });
 
-  const [likingIds, setLikingIds] = useState<Set<number>>(new Set());
+  const likingIdsRef = useRef<Set<number>>(new Set());
 
   const [toastMessage, setToastMessage] = useState<string | null>(null);
 
@@ -61,9 +61,10 @@ export default function PartyListScreen(){
 
   const handleToggleLike = async (partyId: number) => {
     const tab = selectedTab;
-    if (likingIds.has(partyId)) return;
 
-    setLikingIds((prev) => new Set(prev).add(partyId));
+    if (likingIdsRef.current.has(partyId)) return;
+
+    likingIdsRef.current.add(partyId);
     toggleLikeInState(tab, partyId);
 
     try {
@@ -75,11 +76,7 @@ export default function PartyListScreen(){
       setToastMessage("찜 처리에 실패했어요.");
       setTimeout(() => setToastMessage(null), 1500);
     } finally {
-      setLikingIds((prev) => {
-        const next = new Set(prev);
-        next.delete(partyId);
-        return next;
-      });
+      likingIdsRef.current.delete(partyId);
     }
   };
 

--- a/app/main-screens/party-list.tsx
+++ b/app/main-screens/party-list.tsx
@@ -42,9 +42,6 @@ export default function PartyListScreen(){
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
 
   const isInitialLoading = isFetching[selectedTab] && partyData.length === 0;
-  
-  const selectedParty =
-    partyData.find((party) => party.partyId === selectedPartyId) ?? null;
 
   const toggleLikeInState = (tab: TabType, partyId: number) => {
     if (tab === "ALL") {
@@ -87,8 +84,8 @@ export default function PartyListScreen(){
   };
 
   const handleSelectParty = (party: PartyItem) => {
-      setSelectedPartyId(party.partyId);
-      setIsBottomSheetOpen(true);
+    setSelectedPartyId(party.partyId);
+    setIsBottomSheetOpen(true);
   };
 
   const clearSelection = () => {
@@ -175,8 +172,11 @@ export default function PartyListScreen(){
 
       <PartyBottomSheet
         isVisible={isBottomSheetOpen}
-        party={selectedParty}
-        onClose={() => { setIsBottomSheetOpen(false);}}
+        partyId={selectedPartyId}
+        onClose={() => {
+          setIsBottomSheetOpen(false);
+          setSelectedPartyId(null);
+        }}
         onToggleLike={handleToggleLike}
       />
 

--- a/app/main-screens/party-list.tsx
+++ b/app/main-screens/party-list.tsx
@@ -10,7 +10,7 @@ import PartyListBar from "@/components/bars/PartyListBar";
 import LoadingOverlay from "@/components/loadings/LoadingOverlay";
 import ShortToast from "@/components/toasts/ShortToast";
 
-import { getPartyList, PartyListType } from "@/apis/partyApi";
+import { getPartyList, PartyListType, togglePartyLike } from "@/apis/partyApi";
 
 type TabType = "ALL" | "MY";
 
@@ -30,6 +30,8 @@ export default function PartyListScreen(){
     MY: false,
   });
 
+  const [likingIds, setLikingIds] = useState<Set<number>>(new Set());
+
   const [toastMessage, setToastMessage] = useState<string | null>(null);
 
   const partyData = useMemo(() => {
@@ -44,19 +46,43 @@ export default function PartyListScreen(){
   const selectedParty =
     partyData.find((party) => party.partyId === selectedPartyId) ?? null;
 
-  const handleToggleLike = (id: number) => {
-    if (selectedTab === "ALL") {
+  const toggleLikeInState = (tab: TabType, partyId: number) => {
+    if (tab === "ALL") {
       setAllPartyData((prev) =>
         prev.map((item) =>
-          item.partyId === id ? { ...item, isLiked: !item.isLiked } : item
+          item.partyId === partyId ? { ...item, isLiked: !item.isLiked } : item
         )
       );
     } else {
       setMyPartyData((prev) =>
         prev.map((item) =>
-          item.partyId === id ? { ...item, isLiked: !item.isLiked } : item
+          item.partyId === partyId ? { ...item, isLiked: !item.isLiked } : item
         )
       );
+    }
+  };
+
+  const handleToggleLike = async (partyId: number) => {
+    const tab = selectedTab;
+    if (likingIds.has(partyId)) return;
+
+    setLikingIds((prev) => new Set(prev).add(partyId));
+    toggleLikeInState(tab, partyId);
+
+    try {
+      await togglePartyLike(partyId);
+    } catch (e) {
+      toggleLikeInState(tab, partyId);
+
+      console.warn("파티 찜 실패:", e);
+      setToastMessage("찜 처리에 실패했어요.");
+      setTimeout(() => setToastMessage(null), 1500);
+    } finally {
+      setLikingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(partyId);
+        return next;
+      });
     }
   };
 
@@ -95,7 +121,7 @@ export default function PartyListScreen(){
       setHasMore((prev) => ({ ...prev, [tab]: !res.last }));
 
       const lastItem = newItems[newItems.length - 1];
-      if (lastItem) setCursor((prev) => ({ ...prev, [tab]: lastItem.partyId }));
+      setCursor((prev) => ({ ...prev, [tab]: lastItem ? lastItem.partyId : undefined }));
     } catch (e) {
       console.warn("파티 목록 조회 실패:", e);
       setToastMessage("파티 목록을 불러오지 못했어요.");
@@ -109,14 +135,14 @@ export default function PartyListScreen(){
     setIsBottomSheetOpen(false);
     setSelectedPartyId(null);
 
-    if (selectedTab === "ALL" && allPartyData.length === 0) {
-      setCursor((prev) => ({ ...prev, ALL: undefined }));
-      setHasMore((prev) => ({ ...prev, ALL: true }));
+    setCursor((prev) => ({ ...prev, [selectedTab]: undefined }));
+    setHasMore((prev) => ({ ...prev, [selectedTab]: true }));
+
+    if (selectedTab === "ALL") {
+      setAllPartyData([]);
       loadParties("ALL", "RESET");
-    }
-    if (selectedTab === "MY" && myPartyData.length === 0) {
-      setCursor((prev) => ({ ...prev, MY: undefined }));
-      setHasMore((prev) => ({ ...prev, MY: true }));
+    } else {
+      setMyPartyData([]);
       loadParties("MY", "RESET");
     }
   }, [selectedTab]);

--- a/app/main-screens/party-list.tsx
+++ b/app/main-screens/party-list.tsx
@@ -31,6 +31,22 @@ export default function PartyListScreen(){
     MY: false,
   });
 
+  const cursorRef = useRef(cursor);
+  const hasMoreRef = useRef(hasMore);
+  const isFetchingRef = useRef(isFetching);
+
+  useEffect(() => {
+    cursorRef.current = cursor;
+  }, [cursor]);
+
+  useEffect(() => {
+    hasMoreRef.current = hasMore;
+  }, [hasMore]);
+
+  useEffect(() => {
+    isFetchingRef.current = isFetching;
+  }, [isFetching]);
+
   const likingIdsRef = useRef<Set<number>>(new Set());
 
   const [toastMessage, setToastMessage] = useState<string | null>(null);
@@ -97,26 +113,31 @@ export default function PartyListScreen(){
 
   const loadParties = useCallback(
     async (tab: TabType, mode: "RESET" | "MORE", forceReset?: boolean) => {
+      const fetching = isFetchingRef.current[tab];
+      const more = hasMoreRef.current[tab];
+      const lastCursor = cursorRef.current[tab];
+
       if (!forceReset) {
-        if (isFetching[tab]) return;
-        if (mode === "MORE" && !hasMore[tab]) return;
+        if (fetching) return;
+        if (mode === "MORE" && !more) return;
       }
 
       setIsFetching((prev) => ({ ...prev, [tab]: true }));
+
       try {
         const type = getListTypeByTab(tab);
-        const lastId = mode === "RESET" ? undefined : cursor[tab];
+        const lastId = mode === "RESET" || forceReset ? undefined : lastCursor;
 
         const res = await getPartyList(type, { lastParticipantId: lastId });
         const newItems = res.content ?? [];
 
         if (tab === "ALL") {
           setAllPartyData((prev) =>
-            mode === "RESET" ? newItems : [...prev, ...newItems]
+            mode === "RESET" || forceReset ? newItems : [...prev, ...newItems]
           );
         } else {
           setMyPartyData((prev) =>
-            mode === "RESET" ? newItems : [...prev, ...newItems]
+            mode === "RESET" || forceReset ? newItems : [...prev, ...newItems]
           );
         }
 
@@ -129,49 +150,51 @@ export default function PartyListScreen(){
         }));
       } catch (e) {
         console.warn("파티 목록 조회 실패:", e);
+
         setToastMessage("파티 목록을 불러오지 못했어요.");
         setTimeout(() => setToastMessage(null), 1500);
       } finally {
         setIsFetching((prev) => ({ ...prev, [tab]: false }));
       }
     },
-    [isFetching, hasMore, cursor]
+    []
   );
 
-  const didMountRef = useRef(false);
+  const refreshTab = useCallback(
+    (tab: TabType) => {
+      setIsBottomSheetOpen(false);
+      setSelectedPartyId(null);
 
+      setCursor((prev) => ({ ...prev, [tab]: undefined }));
+      setHasMore((prev) => ({ ...prev, [tab]: true }));
+
+      if (tab === "ALL") setAllPartyData([]);
+      else setMyPartyData([]);
+
+      loadParties(tab, "RESET", true);
+    },
+    [loadParties]
+  );
+
+  const handleChangeTab = useCallback(
+    (tab: TabType) => {
+      if (tab === selectedTab) return;
+
+      setSelectedTab(tab);
+      refreshTab(tab);
+    },
+    [selectedTab, refreshTab]
+  );
+
+  const selectedTabRef = useRef<TabType>(selectedTab);
   useEffect(() => {
-    if (!didMountRef.current) {
-      didMountRef.current = true;
-      return;
-    }
-
-    setIsBottomSheetOpen(false);
-    setSelectedPartyId(null);
-
-    if (selectedTab === "ALL") {
-      if (allPartyData.length > 0) return;
-      loadParties("ALL", "RESET");
-    } else {
-      if (myPartyData.length > 0) return;
-      loadParties("MY", "RESET");
-    }
+    selectedTabRef.current = selectedTab;
   }, [selectedTab]);
 
   useFocusEffect(
     useCallback(() => {
-      setIsBottomSheetOpen(false);
-      setSelectedPartyId(null);
-
-      setCursor({ ALL: undefined, MY: undefined });
-      setHasMore({ ALL: true, MY: true });
-
-      setAllPartyData([]);
-      setMyPartyData([]);
-
-      loadParties("ALL", "RESET", true);
-      loadParties("MY", "RESET", true);
-    }, [])
+      refreshTab(selectedTabRef.current);
+    }, [refreshTab])
   );
 
   return (
@@ -179,7 +202,7 @@ export default function PartyListScreen(){
       <TouchableOpacity activeOpacity={1} style={{ flex: 1 }} onPress={clearSelection}>
         <View style={{ flex: 1, backgroundColor: colors.white }}>
           <PartyListTitle title="파티 목록" />
-          <PartyListBar selectedTab={selectedTab} onChangeTab={setSelectedTab} />
+          <PartyListBar selectedTab={selectedTab} onChangeTab={handleChangeTab} />
             <FlatList
               data={[{ key: "only" }]}
               keyExtractor={(item) => item.key}

--- a/app/main-screens/party-list.tsx
+++ b/app/main-screens/party-list.tsx
@@ -1,31 +1,63 @@
-import React, { useState } from "react";
-import { ScrollView, TouchableOpacity } from "react-native";
+import React, { useState, useMemo, useEffect } from "react";
+import { View, TouchableOpacity, FlatList } from "react-native";
 import PartyList from "@/components/lists/PartyList";
 import PartyBottomSheet from "@/components/sections/PartyBottomSheet";
 
 import type { PartyItem } from "@/types/party";
-import { parties } from "@/mocks/parties";
 import { colors } from "@/constants/colors";
 import PartyListTitle from "@/components/titles/PartyListTitle";
 import PartyListBar from "@/components/bars/PartyListBar";
+import LoadingOverlay from "@/components/loadings/LoadingOverlay";
+import ShortToast from "@/components/toasts/ShortToast";
+
+import { getPartyList, PartyListType } from "@/apis/partyApi";
+
+type TabType = "ALL" | "MY";
 
 export default function PartyListScreen(){
-  
-  const [partyData, setPartyData] = useState(parties);
-  const [selectedTab, setSelectedTab] = useState<"ALL" | "MY">("ALL");
+  const [selectedTab, setSelectedTab] = useState<TabType>("ALL");
+
+  const [allPartyData, setAllPartyData] = useState<PartyItem[]>([]);
+  const [myPartyData, setMyPartyData] = useState<PartyItem[]>([]);
+
+  const [cursor, setCursor] = useState<{ ALL?: number; MY?: number }>({});
+  const [hasMore, setHasMore] = useState<{ ALL: boolean; MY: boolean }>({
+    ALL: true,
+    MY: true,
+  });
+  const [isFetching, setIsFetching] = useState<{ ALL: boolean; MY: boolean }>({
+    ALL: false,
+    MY: false,
+  });
+
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+
+  const partyData = useMemo(() => {
+    return selectedTab === "ALL" ? allPartyData : myPartyData;
+  }, [selectedTab, allPartyData, myPartyData]);
 
   const [selectedPartyId, setSelectedPartyId] = useState<number | null>(null);
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+
+  const isInitialLoading = isFetching[selectedTab] && partyData.length === 0;
   
   const selectedParty =
     partyData.find((party) => party.partyId === selectedPartyId) ?? null;
 
   const handleToggleLike = (id: number) => {
-    setPartyData(prev =>
-      prev.map(item =>
-        item.partyId === id ? { ...item, isLiked: !item.isLiked } : item
-      )
-    );
+    if (selectedTab === "ALL") {
+      setAllPartyData((prev) =>
+        prev.map((item) =>
+          item.partyId === id ? { ...item, isLiked: !item.isLiked } : item
+        )
+      );
+    } else {
+      setMyPartyData((prev) =>
+        prev.map((item) =>
+          item.partyId === id ? { ...item, isLiked: !item.isLiked } : item
+        )
+      );
+    }
   };
 
   const handleSelectParty = (party: PartyItem) => {
@@ -37,27 +69,82 @@ export default function PartyListScreen(){
     if (!isBottomSheetOpen) setSelectedPartyId(null);
   };
 
+  const getListTypeByTab = (tab: TabType): PartyListType => {
+    if (tab === "ALL") return "participant";
+    return "host";
+  };
+
+  const loadParties = async (tab: TabType, mode: "RESET" | "MORE") => {
+    if (isFetching[tab]) return;
+    if (mode === "MORE" && !hasMore[tab]) return;
+
+    setIsFetching((prev) => ({ ...prev, [tab]: true }));
+    try {
+      const type = getListTypeByTab(tab);
+      const lastId = mode === "RESET" ? undefined : cursor[tab];
+
+      const res = await getPartyList(type, { lastParticipantId: lastId });
+      const newItems = res.content ?? [];
+
+      if (tab === "ALL") {
+        setAllPartyData((prev) => (mode === "RESET" ? newItems : [...prev, ...newItems]));
+      } else {
+        setMyPartyData((prev) => (mode === "RESET" ? newItems : [...prev, ...newItems]));
+      }
+
+      setHasMore((prev) => ({ ...prev, [tab]: !res.last }));
+
+      const lastItem = newItems[newItems.length - 1];
+      if (lastItem) setCursor((prev) => ({ ...prev, [tab]: lastItem.partyId }));
+    } catch (e) {
+      console.warn("파티 목록 조회 실패:", e);
+      setToastMessage("파티 목록을 불러오지 못했어요.");
+      setTimeout(() => setToastMessage(null), 1500);
+    } finally {
+      setIsFetching((prev) => ({ ...prev, [tab]: false }));
+    }
+  };
+
+  useEffect(() => {
+    setIsBottomSheetOpen(false);
+    setSelectedPartyId(null);
+
+    if (selectedTab === "ALL" && allPartyData.length === 0) {
+      setCursor((prev) => ({ ...prev, ALL: undefined }));
+      setHasMore((prev) => ({ ...prev, ALL: true }));
+      loadParties("ALL", "RESET");
+    }
+    if (selectedTab === "MY" && myPartyData.length === 0) {
+      setCursor((prev) => ({ ...prev, MY: undefined }));
+      setHasMore((prev) => ({ ...prev, MY: true }));
+      loadParties("MY", "RESET");
+    }
+  }, [selectedTab]);
+
   return (
     <>
-      <TouchableOpacity 
-        activeOpacity={1} 
-        style={{ flex: 1 }} 
-        onPress={clearSelection}
-      >
-        <ScrollView className="flex-1" style={{ backgroundColor: colors.white }}>
-          <PartyListTitle title="파티 목록"/>
-          <PartyListBar
-            selectedTab={selectedTab}
-            onChangeTab={setSelectedTab}
-          />
-          <PartyList 
-            partyData={partyData} 
-            countPartyNum={10}
-            onToggleLike={handleToggleLike}
-            onSelectParty={handleSelectParty}
-            selectedPartyId={selectedPartyId}
-          />
-        </ScrollView>
+      <TouchableOpacity activeOpacity={1} style={{ flex: 1 }} onPress={clearSelection}>
+        <View style={{ flex: 1, backgroundColor: colors.white }}>
+          <PartyListTitle title="파티 목록" />
+          <PartyListBar selectedTab={selectedTab} onChangeTab={setSelectedTab} />
+            <FlatList
+              data={[{ key: "only" }]}
+              keyExtractor={(item) => item.key}
+              renderItem={() => (
+                <PartyList
+                  partyData={partyData}
+                  countPartyNum={partyData.length}
+                  onToggleLike={handleToggleLike}
+                  onSelectParty={handleSelectParty}
+                  selectedPartyId={selectedPartyId}
+                  isLoading={isInitialLoading}
+                />
+              )}
+              onEndReachedThreshold={0.6}
+              onEndReached={() => loadParties(selectedTab, "MORE")}
+              contentContainerStyle={{ paddingTop: 16, paddingBottom: 90 }}
+            />
+        </View>
       </TouchableOpacity>
 
       <PartyBottomSheet
@@ -66,6 +153,10 @@ export default function PartyListScreen(){
         onClose={() => { setIsBottomSheetOpen(false);}}
         onToggleLike={handleToggleLike}
       />
+
+      {toastMessage && <ShortToast message={toastMessage} />}
+
+      <LoadingOverlay visible={isInitialLoading} />
     </>
   );
 }

--- a/app/main-screens/party-list.tsx
+++ b/app/main-screens/party-list.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useMemo, useEffect, useRef } from "react";
+import React, { useState, useMemo, useEffect, useRef, useCallback} from "react";
+import { useFocusEffect } from "@react-navigation/native";
 import { View, TouchableOpacity, FlatList } from "react-native";
 import PartyList from "@/components/lists/PartyList";
 import PartyBottomSheet from "@/components/sections/PartyBottomSheet";
@@ -94,52 +95,84 @@ export default function PartyListScreen(){
     return "host";
   };
 
-  const loadParties = async (tab: TabType, mode: "RESET" | "MORE") => {
-    if (isFetching[tab]) return;
-    if (mode === "MORE" && !hasMore[tab]) return;
-
-    setIsFetching((prev) => ({ ...prev, [tab]: true }));
-    try {
-      const type = getListTypeByTab(tab);
-      const lastId = mode === "RESET" ? undefined : cursor[tab];
-
-      const res = await getPartyList(type, { lastParticipantId: lastId });
-      const newItems = res.content ?? [];
-
-      if (tab === "ALL") {
-        setAllPartyData((prev) => (mode === "RESET" ? newItems : [...prev, ...newItems]));
-      } else {
-        setMyPartyData((prev) => (mode === "RESET" ? newItems : [...prev, ...newItems]));
+  const loadParties = useCallback(
+    async (tab: TabType, mode: "RESET" | "MORE", forceReset?: boolean) => {
+      if (!forceReset) {
+        if (isFetching[tab]) return;
+        if (mode === "MORE" && !hasMore[tab]) return;
       }
 
-      setHasMore((prev) => ({ ...prev, [tab]: !res.last }));
+      setIsFetching((prev) => ({ ...prev, [tab]: true }));
+      try {
+        const type = getListTypeByTab(tab);
+        const lastId = mode === "RESET" ? undefined : cursor[tab];
 
-      const lastItem = newItems[newItems.length - 1];
-      setCursor((prev) => ({ ...prev, [tab]: lastItem ? lastItem.partyId : undefined }));
-    } catch (e) {
-      console.warn("파티 목록 조회 실패:", e);
-      setToastMessage("파티 목록을 불러오지 못했어요.");
-      setTimeout(() => setToastMessage(null), 1500);
-    } finally {
-      setIsFetching((prev) => ({ ...prev, [tab]: false }));
-    }
-  };
+        const res = await getPartyList(type, { lastParticipantId: lastId });
+        const newItems = res.content ?? [];
+
+        if (tab === "ALL") {
+          setAllPartyData((prev) =>
+            mode === "RESET" ? newItems : [...prev, ...newItems]
+          );
+        } else {
+          setMyPartyData((prev) =>
+            mode === "RESET" ? newItems : [...prev, ...newItems]
+          );
+        }
+
+        setHasMore((prev) => ({ ...prev, [tab]: !res.last }));
+
+        const lastItem = newItems[newItems.length - 1];
+        setCursor((prev) => ({
+          ...prev,
+          [tab]: lastItem ? lastItem.partyId : undefined,
+        }));
+      } catch (e) {
+        console.warn("파티 목록 조회 실패:", e);
+        setToastMessage("파티 목록을 불러오지 못했어요.");
+        setTimeout(() => setToastMessage(null), 1500);
+      } finally {
+        setIsFetching((prev) => ({ ...prev, [tab]: false }));
+      }
+    },
+    [isFetching, hasMore, cursor]
+  );
+
+  const didMountRef = useRef(false);
 
   useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
+
     setIsBottomSheetOpen(false);
     setSelectedPartyId(null);
 
-    setCursor((prev) => ({ ...prev, [selectedTab]: undefined }));
-    setHasMore((prev) => ({ ...prev, [selectedTab]: true }));
-
     if (selectedTab === "ALL") {
-      setAllPartyData([]);
+      if (allPartyData.length > 0) return;
       loadParties("ALL", "RESET");
     } else {
-      setMyPartyData([]);
+      if (myPartyData.length > 0) return;
       loadParties("MY", "RESET");
     }
   }, [selectedTab]);
+
+  useFocusEffect(
+    useCallback(() => {
+      setIsBottomSheetOpen(false);
+      setSelectedPartyId(null);
+
+      setCursor({ ALL: undefined, MY: undefined });
+      setHasMore({ ALL: true, MY: true });
+
+      setAllPartyData([]);
+      setMyPartyData([]);
+
+      loadParties("ALL", "RESET", true);
+      loadParties("MY", "RESET", true);
+    }, [])
+  );
 
   return (
     <>

--- a/app/signup/my-location.tsx
+++ b/app/signup/my-location.tsx
@@ -3,7 +3,7 @@ import { View, KeyboardAvoidingView, Platform, SafeAreaView,
     TouchableWithoutFeedback, Keyboard, Alert
  } from "react-native";
 import { useRouter } from "expo-router";
-import type { KakaoPlace } from "@/types/kakao-place";
+import type { KakaoPlace } from "@/types/place";
 
 import SignupTitle from "@/components/titles/SignupTitle";
 import SignupBar from "@/components/bars/SignupBar";

--- a/components/bars/PartySortFilterBar.tsx
+++ b/components/bars/PartySortFilterBar.tsx
@@ -42,7 +42,7 @@ export default function PartySortFilterBar({
 
   return (
     <View
-      className="mx-5 mt-6"
+      className="mx-5 mt-6 mb-4"
       style={{
         position: "relative",
         zIndex: hasOverlay ? 30 : 0,

--- a/components/buttons/PartyBottomSheetButton.tsx
+++ b/components/buttons/PartyBottomSheetButton.tsx
@@ -5,9 +5,8 @@ import { colors } from "@/constants/colors";
 import { fonts } from "@/constants/fonts";
 import PartyChatLinkModal from "../modals/PartyChatLinkModal";
 import type { PartyItem } from "@/types/party";
-import ShortToast from "@/components/toasts/ShortToast";
+import ShortToast from "../toasts/ShortToast";
 
-import axios from "axios";
 import { confirmParty } from "@/apis/partyApi";
 
 type PartyBottomSheetButtonProps = {
@@ -63,17 +62,13 @@ export default function PartyBottomSheetButton({
     const trimmed = chatUrl.trim();
 
     if (!trimmed) {
-      setToastMessage("오픈채팅방 링크를 입력해주세요.");
-      setTimeout(() => setToastMessage(null), 1500);
-      return;
+      throw new Error("오픈채팅방 링크를 입력해주세요.");
     }
 
     // 카카오 오픈채팅 URL 검증
     const isValid = /^https:\/\/open\.kakao\.com\/o\/.+/.test(trimmed);
     if (!isValid) {
-      setToastMessage("올바른 오픈채팅방 링크를 입력해주세요.");
-      setTimeout(() => setToastMessage(null), 1500);
-      return;
+      throw new Error("올바른 오픈채팅방 링크를 입력해주세요.");
     }
 
     try {
@@ -87,27 +82,28 @@ export default function PartyBottomSheetButton({
 
       setToastMessage("파티가 확정되었습니다!");
       setTimeout(() => setToastMessage(null), 1500);
-    } catch (e: unknown) {
-      let msg = "파티 확정에 실패했어요. 다시 시도해주세요.";
-      if (axios.isAxiosError(e)) {
-        const data = e.response?.data as any;
-        const serverMsg =
-          data?.data?.message ||
-          data?.message ||
-          data?.error ||
-          data?.detail ||
-          data?.title;
+    // } catch (e: unknown) {
+    //   let msg = "파티 확정에 실패했어요. 다시 시도해주세요.";
+    //   if (axios.isAxiosError(e)) {
+    //     const data = e.response?.data as any;
+    //     const serverMsg =
+    //       data?.data?.message ||
+    //       data?.message ||
+    //       data?.error ||
+    //       data?.detail ||
+    //       data?.title;
 
-        if (typeof serverMsg === "string" && serverMsg.trim()) {
-          msg = serverMsg;
-        }
+    //     if (typeof serverMsg === "string" && serverMsg.trim()) {
+    //       msg = serverMsg;
+    //     }
 
-        console.warn("파티 확정 실패:", e.response?.status, e.response?.data);
-      } else {
-        console.warn("파티 확정 실패:", e);
-      }
+    //     console.warn("파티 확정 실패:", e.response?.status, e.response?.data);
+    //     throw new Error(msg);
+    //   } else {
+    //     console.warn("파티 확정 실패:", e);
+    //   }
 
-      throw new Error(msg);
+    //   throw new Error(msg);
     } finally {
       setIsConfirming(false);
     }
@@ -211,6 +207,7 @@ const buttonLabel = getButtonLabel();
         onCancel={() => setIsChatModalVisible(false)}
         onConfirm={handleChatConfirm}
       />
+      {toastMessage && <ShortToast message={toastMessage} />}
     </>
   );
 }

--- a/components/buttons/PartyBottomSheetButton.tsx
+++ b/components/buttons/PartyBottomSheetButton.tsx
@@ -8,16 +8,14 @@ import type { PartyItem } from "@/types/party";
 
 type PartyBottomSheetButtonProps = {
   party: PartyItem;
-  memberId: number;
   onToggleLike?: (id: number) => void;
 };
 
 export default function PartyBottomSheetButton({
   party,
-  memberId,
   onToggleLike,
 }: PartyBottomSheetButtonProps) {
-  const isHost = party.host.memberId === memberId;
+  const isHost = party.role === "HOST";
 
   const [partyStatus, setPartyStatus] = useState<PartyItem["status"]>(
     party.status

--- a/components/buttons/PartyBottomSheetButton.tsx
+++ b/components/buttons/PartyBottomSheetButton.tsx
@@ -5,15 +5,21 @@ import { colors } from "@/constants/colors";
 import { fonts } from "@/constants/fonts";
 import PartyChatLinkModal from "../modals/PartyChatLinkModal";
 import type { PartyItem } from "@/types/party";
+import ShortToast from "@/components/toasts/ShortToast";
+
+import axios from "axios";
+import { confirmParty } from "@/apis/partyApi";
 
 type PartyBottomSheetButtonProps = {
   party: PartyItem;
   onToggleLike?: (id: number) => void;
+  onConfirmed?: () => Promise<void> | void;
 };
 
 export default function PartyBottomSheetButton({
   party,
   onToggleLike,
+  onConfirmed,
 }: PartyBottomSheetButtonProps) {
   const isHost = party.role === "HOST";
 
@@ -25,16 +31,20 @@ export default function PartyBottomSheetButton({
   const [isChatModalVisible, setIsChatModalVisible] = useState(false);
   const [chatUrl, setChatUrl] = useState(party.chatUrl ?? "");
 
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [isConfirming, setIsConfirming] = useState(false);
+
   useEffect(() => {
     setPartyStatus(party.status);
     setIsPartyJoined(false);
+    setChatUrl(party.chatUrl ?? "");
   }, [party]);
 
   const isRecruiting = partyStatus === "RECRUITING";
   const isRecruitCompleted = partyStatus === "RECRUIT_COMPLETED";
   const isCompleted = partyStatus === "COMPLETED";
 
-  const isButtonDisabled = isRecruitCompleted || isCompleted;
+  const isButtonDisabled = isRecruitCompleted || isCompleted || isConfirming;;
 
   const handlePartyJoin = () => {
     if (!isRecruiting || isHost || isButtonDisabled) return;
@@ -47,9 +57,60 @@ export default function PartyBottomSheetButton({
   };
 
   // 오카방 링크 입력 후 파티 status 변경
-  const handleChatConfirm = () => {
-    setPartyStatus("RECRUIT_COMPLETED");
-    setIsChatModalVisible(false);
+  const handleChatConfirm = async () => {
+    if (!party.partyId) return;
+
+    const trimmed = chatUrl.trim();
+
+    if (!trimmed) {
+      setToastMessage("오픈채팅방 링크를 입력해주세요.");
+      setTimeout(() => setToastMessage(null), 1500);
+      return;
+    }
+
+    // 카카오 오픈채팅 URL 검증
+    const isValid = /^https:\/\/open\.kakao\.com\/o\/.+/.test(trimmed);
+    if (!isValid) {
+      setToastMessage("올바른 오픈채팅방 링크를 입력해주세요.");
+      setTimeout(() => setToastMessage(null), 1500);
+      return;
+    }
+
+    try {
+      setIsConfirming(true);
+
+      await confirmParty(party.partyId, { chatUrl: trimmed });
+
+      await onConfirmed?.();
+      setPartyStatus("RECRUIT_COMPLETED");
+      setIsChatModalVisible(false);
+
+      setToastMessage("파티가 확정되었습니다!");
+      setTimeout(() => setToastMessage(null), 1500);
+    } catch (e: unknown) {
+      let msg = "파티 확정에 실패했어요. 다시 시도해주세요.";
+      if (axios.isAxiosError(e)) {
+        const data = e.response?.data as any;
+        const serverMsg =
+          data?.data?.message ||
+          data?.message ||
+          data?.error ||
+          data?.detail ||
+          data?.title;
+
+        if (typeof serverMsg === "string" && serverMsg.trim()) {
+          msg = serverMsg;
+        }
+
+        console.warn("파티 확정 실패:", e.response?.status, e.response?.data);
+      } else {
+        console.warn("파티 확정 실패:", e);
+      }
+
+      throw new Error(msg);
+    } finally {
+      setIsConfirming(false);
+    }
   };
 
   const getButtonBackgroundColor = () => {

--- a/components/buttons/PartyBottomSheetButton.tsx
+++ b/components/buttons/PartyBottomSheetButton.tsx
@@ -82,28 +82,6 @@ export default function PartyBottomSheetButton({
 
       setToastMessage("파티가 확정되었습니다!");
       setTimeout(() => setToastMessage(null), 1500);
-    // } catch (e: unknown) {
-    //   let msg = "파티 확정에 실패했어요. 다시 시도해주세요.";
-    //   if (axios.isAxiosError(e)) {
-    //     const data = e.response?.data as any;
-    //     const serverMsg =
-    //       data?.data?.message ||
-    //       data?.message ||
-    //       data?.error ||
-    //       data?.detail ||
-    //       data?.title;
-
-    //     if (typeof serverMsg === "string" && serverMsg.trim()) {
-    //       msg = serverMsg;
-    //     }
-
-    //     console.warn("파티 확정 실패:", e.response?.status, e.response?.data);
-    //     throw new Error(msg);
-    //   } else {
-    //     console.warn("파티 확정 실패:", e);
-    //   }
-
-    //   throw new Error(msg);
     } finally {
       setIsConfirming(false);
     }

--- a/components/inputs/CreatePartyInput.tsx
+++ b/components/inputs/CreatePartyInput.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useRef, useEffect } from "react";
 import { View, TextInput, } from "react-native";
 import { getDateRange, toKSTIsoString } from "@/utils/dateTime";
 import { PartyType, RouteType, GenderType } from "@/types/party";
-import type { KakaoPlace } from "@/types/kakao-place";
+import type { KakaoPlace } from "@/types/place";
 import { searchKakaoPlaces } from "@/apis/kakaoApi";
 
 import Label from "./create-party/InputLabel";
@@ -16,6 +16,9 @@ import EtcSection from "./create-party/EtcSection";
 
 import CreatePartyButton from "../buttons/CreatePartyButton";
 import KakaoPlaceSearchModal from "../modals/KakaoPlaceSearchModal";
+
+import ShortToast from "@/components/toasts/ShortToast";
+import { createParty } from "@/apis/partyApi";
 
 interface CreatePartyInputProps {
   eventId: number;
@@ -121,7 +124,8 @@ export default function CreatePartyInput({
   const [etc, setEtc] = useState("");
 
   // 입력폼 유효성 확인
-  const isRoundTrip = routeType === "ROUND_TRIP";
+  const needsTransport = partyType !== "SCHEDULE_ONLY";
+  const isRoundTrip = needsTransport && routeType === "ROUND_TRIP";
 
   const isTimeValid =
     !!startAt && (!isRoundTrip || !!returnAt);
@@ -133,30 +137,32 @@ export default function CreatePartyInput({
     !!eventId &&
     !!partyDate &&
     !!partyType &&
-    !!routeType &&
-    !!departurePlace &&
+    !!departurePlace && 
     !!arrivalPlace &&
     !!capacity &&
     !!genderLimit;
 
   const isFormValid = isBasicFilled && isTimeValid && isAgeValid;
 
-  const handleCreateParty = () => {
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+
+  const handleCreateParty = async () => {
     if (!isFormValid) {
-      console.log("필수 항목이 모두 채워지지 않았습니다.");
+      setToastMessage("항목을 모두 입력해주세요.");
+      setTimeout(() => setToastMessage(null), 1500);
       return;
     }
 
     const startAtIso = toKSTIsoString(partyDate, startAt);
     const endAtIso =
-    routeType === "ROUND_TRIP" && returnAt
+    partyType !== "SCHEDULE_ONLY" && routeType === "ROUND_TRIP" && returnAt
       ? toKSTIsoString(partyDate, returnAt)
       : null;
 
     const body = {
       eventId: eventId,
       type: partyType,
-      routeType: routeType,
+      routeType: partyType === "SCHEDULE_ONLY" ? null : routeType,
       gender: genderLimit,
       capacity: Number(capacity),
       maxBirthYear: hasAgeLimit && maxBirthYear ? Number(maxBirthYear) : null,
@@ -164,11 +170,22 @@ export default function CreatePartyInput({
       startAt: startAtIso,
       endAt: endAtIso,
       description: etc,
-      departure: departurePlace,
-      arrival: arrivalPlace,
+      departure: departurePlace!,
+      arrival: arrivalPlace!,
     };
-    console.log(body);
-    onCreateSuccess?.(); 
+    try {
+      await createParty(body);
+
+      setToastMessage("파티가 생성되었습니다!");
+      setTimeout(() => {
+        setToastMessage(null);
+        onCreateSuccess?.();
+      }, 1200);
+    } catch (e) {
+      console.warn("파티 생성 실패:", e);
+      setToastMessage("파티 생성에 실패했어요. 다시 시도해주세요.");
+      setTimeout(() => setToastMessage(null), 1500);
+    }
   };
 
   return (
@@ -192,18 +209,20 @@ export default function CreatePartyInput({
           />
         </View>
 
-        <View className="mb-5">
-          <Label>이동 형태</Label>
-          <SegmentGroup<RouteType>
-            options={routeTypeOptions}
-            value={routeType}
-            onChange={setRouteType}
-          />
-        </View>
+        {partyType !== "SCHEDULE_ONLY" && (
+          <View className="mb-5">
+            <Label>이동 형태</Label>
+            <SegmentGroup<RouteType>
+              options={routeTypeOptions}
+              value={routeType}
+              onChange={setRouteType}
+            />
+          </View>
+        )}
 
         <View className="mb-5">
           <Label>장소</Label>
-          <LocationSection
+          <LocationSection  
             departure={departure}
             arrivalLabel={arrivalLabel}
             onChangeDeparture={setDeparture}
@@ -214,6 +233,7 @@ export default function CreatePartyInput({
         <View className="mb-5">
           <Label>집합 시간</Label>
           <TimeSection
+            partyType={partyType}
             routeType={routeType}
             startAt={startAt}
             returnAt={returnAt}
@@ -272,6 +292,7 @@ export default function CreatePartyInput({
         onSelect={handleSelectDeparturePlace}
         title="출발지 검색"
       />
+      {toastMessage && <ShortToast message={toastMessage} />}
     </>
   );
 }

--- a/components/inputs/CreatePartyInput.tsx
+++ b/components/inputs/CreatePartyInput.tsx
@@ -73,35 +73,49 @@ export default function CreatePartyInput({
   const arrivalLabel = facilityName; 
   const [arrivalPlace, setArrivalPlace] = useState<KakaoPlace | null>(null);
 
+  const sanitizePlaceKeyword = (name: string) => {
+    return name
+      .replace(/\(.*?\)/g, "")
+      .replace(/\[.*?\]/g, "")
+      .replace(/\{.*?\}/g, "")
+      .replace(/[·•∙・]/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+  };
+
   // facilityName 기반으로 도착지 위치 검색
+  // facilityName으로 위치 검색 실패하면 정제 키워드로 재검색
   useEffect(() => {
-    let isMounted = true;
+  let isMounted = true;
 
-    const fetchArrivalPlace = async () => {
-      if (!facilityName) return;
+  const fetchArrivalPlace = async () => {
+    if (!facilityName) return;
 
-      try {
-        const results = await searchKakaoPlaces(facilityName);
+    try {
+      let results = await searchKakaoPlaces(facilityName);
 
-        if (!isMounted) return;
+      if (results.length === 0) {
+        const parsed = sanitizePlaceKeyword(facilityName);
 
-        if (results.length > 0) {
-          setArrivalPlace(results[0]);
-        } else {
-          setArrivalPlace(null);
+        if (parsed && parsed !== facilityName) {
+          results = await searchKakaoPlaces(parsed);
         }
-      } catch (e) {
-        console.warn("arrival 검색 실패:", e);
-        if (isMounted) setArrivalPlace(null);
       }
-    };
 
-    fetchArrivalPlace();
+      if (!isMounted) return;
 
-    return () => {
-      isMounted = false;
-    };
-  }, [facilityName]);
+      setArrivalPlace(results.length > 0 ? results[0] : null);
+    } catch (e) {
+      console.warn("arrival 검색 실패:", e);
+      if (isMounted) setArrivalPlace(null);
+    }
+  };
+
+  fetchArrivalPlace();
+  return () => {
+    isMounted = false;
+  };
+}, [facilityName]);
 
   const [startAt, setStartAt] = useState("");
   const [returnAt, setReturnAt] = useState(""); 

--- a/components/inputs/create-party/AgeLimitSection.tsx
+++ b/components/inputs/create-party/AgeLimitSection.tsx
@@ -125,7 +125,7 @@ export default function AgeLimitSection({
               onEndEditing={() =>
                 validateYear(maxBirthYear, onChangeMaxBirthYear, "max")
               }
-              placeholder="예) 2002"
+              placeholder="예) 1995"
               placeholderTextColor={colors.gray}
               keyboardType="number-pad"
               style={[fonts.mediumText, { color: colors.black }]}
@@ -150,7 +150,7 @@ export default function AgeLimitSection({
               onEndEditing={() =>
                 validateYear(minBirthYear, onChangeMinBirthYear, "min")
               }
-              placeholder="예) 1995"
+              placeholder="예) 2000"
               placeholderTextColor={colors.gray}
               keyboardType="number-pad"
               style={[fonts.mediumText, { color: colors.black }]}

--- a/components/inputs/create-party/TimeSection.tsx
+++ b/components/inputs/create-party/TimeSection.tsx
@@ -2,11 +2,12 @@ import React, { useState } from "react";
 import { View, Text, TextInput } from "react-native";
 import { colors } from "@/constants/colors";
 import { fonts } from "@/constants/fonts";
-import type { RouteType } from "@/types/party";
+import type { PartyType, RouteType } from "@/types/party";
 import { inputBoxStyle } from "@/styles/inputBox";
 import ShortToast from "@/components/toasts/ShortToast";
 
 type TimeSectionProps = {
+  partyType: PartyType;
   routeType: RouteType;
   startAt: string;
   returnAt: string;
@@ -15,12 +16,15 @@ type TimeSectionProps = {
 };
 
 export default function TimeSection({
+  partyType,
   routeType,
   startAt,
   returnAt,
   onChangeStartAt,
   onChangeReturnAt,
 }: TimeSectionProps) {
+  const isSingleTime = routeType === "ONE_WAY" || partyType === "SCHEDULE_ONLY";
+
   const [toastMsg, setToastMsg] = useState("");
 
   const showToast = (msg: string) => {
@@ -85,7 +89,7 @@ export default function TimeSection({
   return (
     <>
       <View>
-        {routeType === "ONE_WAY" ? (
+        {isSingleTime ? (
           <View style={[inputBoxStyle, { backgroundColor: "#fff" }]}>
             <TextInput
               value={startAt}

--- a/components/lists/PartyList.tsx
+++ b/components/lists/PartyList.tsx
@@ -11,6 +11,7 @@ type PartyListProps = {
   onToggleLike: (id: number) => void;
   onSelectParty?: (party: PartyItem) => void;
   selectedPartyId?: number | null;
+  isLoading?: boolean;
 };
 
 export default function PartyList({
@@ -19,25 +20,32 @@ export default function PartyList({
   countPartyNum,
   onSelectParty,
   selectedPartyId,
+  isLoading
 }: PartyListProps) {
   const shouldShowEmpty = countPartyNum === 0;
 
-  return (
-    <View className="px-4 py-2 mt-5">
-      {shouldShowEmpty ? (
+  if (isLoading) return null;
+
+  if (shouldShowEmpty) {
+    return (
+      <View className="px-4">
         <EmptyBox message="등록된 파티가 없습니다" />
-      ) : (
-        partyData.map((item) => (
-          <PartyCard
-            key={item.partyId}
-            item={item}
-            selectable
-            isSelected={selectedPartyId === item.partyId}
-            onSelect={onSelectParty}
-            onToggleLike={onToggleLike}
-          />
-        ))
-      )}
+      </View>
+    );
+  }
+
+  return (
+    <View className="px-4">
+      {partyData.map((item) => (
+        <PartyCard
+          key={item.partyId}
+          item={item}
+          selectable
+          isSelected={selectedPartyId === item.partyId}
+          onSelect={onSelectParty}
+          onToggleLike={onToggleLike}
+        />
+      ))}
     </View>
   );
 }

--- a/components/modals/KakaoPlaceSearchModal.tsx
+++ b/components/modals/KakaoPlaceSearchModal.tsx
@@ -12,7 +12,7 @@ import {
 } from "react-native";
 import { colors } from "@/constants/colors";
 import { fonts } from "@/constants/fonts";
-import type { KakaoPlace } from "@/types/kakao-place";
+import type { KakaoPlace } from "@/types/place";
 import { searchKakaoPlaces } from "@/apis/kakaoApi"
 
 type KakaoPlaceSearchModalProps = {

--- a/components/modals/PartyChatLinkModal.tsx
+++ b/components/modals/PartyChatLinkModal.tsx
@@ -1,14 +1,15 @@
-import React from "react";
+import React, { useRef, useState, useEffect } from "react";
 import { Modal, View, Text, TouchableOpacity, TextInput } from "react-native";
 import { colors } from "@/constants/colors";
 import { fonts } from "@/constants/fonts";
+import ShortToast from "../toasts/ShortToast";
 
 type PartyChatLinkModalProps = {
   visible: boolean;
   chatUrl: string;
   onChangeChatUrl: (text: string) => void;
   onCancel: () => void;
-  onConfirm: () => void;
+  onConfirm: () => Promise<void>;
 };
 
 export default function PartyChatLinkModal({
@@ -18,6 +19,36 @@ export default function PartyChatLinkModal({
   onCancel,
   onConfirm,
 }: PartyChatLinkModalProps) {
+  const [toastMsg, setToastMsg] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showToast = (msg: string) => {
+    setToastMsg(msg);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setToastMsg(null), 1500);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const handleConfirmPress = async () => {
+    try {
+      await onConfirm();
+    } catch (e: any) {
+      const msg =
+        e?.message ??
+        e?.data?.message ??
+        e?.response?.data?.data?.message ??
+        e?.response?.data?.message ??
+        "요청에 실패했어요. 다시 시도해주세요.";
+
+      showToast(msg);
+    }
+  };
+
   return (
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onCancel}>
       <View className="flex-1 items-center justify-center bg-black/40">
@@ -50,12 +81,13 @@ export default function PartyChatLinkModal({
             <TouchableOpacity
               className="px-4 py-2 rounded-lg"
               style={{ backgroundColor: colors.orange }}
-              onPress={onConfirm}
+              onPress={handleConfirmPress}
             >
               <Text style={[fonts.smallText, { color: colors.white }]}>확정하기</Text>
             </TouchableOpacity>
           </View>
         </View>
+        {toastMsg && <ShortToast message={toastMsg} />}
       </View>
     </Modal>
   );

--- a/components/sections/PartyBottomSheet.tsx
+++ b/components/sections/PartyBottomSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { View, Text, Image, TouchableOpacity, StyleSheet, Animated, Dimensions, Modal, PanResponder, } from "react-native";
 import { colors } from "@/constants/colors";
 import { fonts } from "@/constants/fonts";
@@ -10,11 +10,11 @@ import PartyBottomSheetButton from "@/components/buttons/PartyBottomSheetButton"
 import PartyChatLinkButton from "@/components/buttons/PartyChatLinkButton";
 import ReviewMemberListButton from "../buttons/ReviewMemberListButton";
 
-import { member } from "@/mocks/member";
+import { getPartyDetail } from "@/apis/partyApi";
 
 type PartyBottomSheetProps = {
   isVisible: boolean;  
-  party: PartyItem | null;
+  partyId: number | null;
   onClose: () => void;
   onToggleLike?: (id: number) => void;
 };
@@ -25,11 +25,14 @@ const CLOSE_THRESHOLD = 70;
 
 export default function PartyBottomSheet({
   isVisible,
-  party,
+  partyId,
   onClose,
   onToggleLike,
 }: PartyBottomSheetProps) {
   const translateY = useRef(new Animated.Value(SHEET_HEIGHT)).current;
+
+  const [party, setParty] = useState<PartyItem | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   const panResponder = useRef(
   PanResponder.create({
@@ -68,7 +71,68 @@ export default function PartyBottomSheet({
     }).start();
   }, [isVisible, translateY]);
 
-  if (!party) return null;
+  useEffect(() => {
+    if (!isVisible) return;
+    if (!partyId) return;
+
+    let alive = true;
+
+    (async () => {
+      setIsLoading(true);
+      try {
+        const detail = await getPartyDetail(partyId);
+        if (!alive) return;
+        setParty(detail);
+      } catch (e) {
+        console.warn("파티 상세 조회 실패:", e);
+        if (!alive) return;
+        setParty(null);
+        onClose();
+      } finally {
+        if (!alive) return;
+        setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, [isVisible, partyId, onClose]);
+
+  if (!isVisible) return null;
+
+  if (isLoading || !party) {
+    return (
+      <Modal visible={isVisible} transparent animationType="fade" onRequestClose={onClose}>
+        <View className="flex-1">
+          <TouchableOpacity style={StyleSheet.absoluteFillObject} activeOpacity={1} onPress={onClose}>
+            <View className="flex-1 bg-black/40" />
+          </TouchableOpacity>
+
+          <Animated.View
+            className="absolute left-0 right-0 rounded-t-3xl"
+            style={{
+              bottom: 0,
+              height: SHEET_HEIGHT,
+              backgroundColor: colors.white,
+              transform: [{ translateY }],
+            }}
+            {...panResponder.panHandlers}
+          >
+            <View className="items-center pt-3 pb-2">
+              <View className="w-12 h-1.5 rounded-full" style={{ backgroundColor: colors.gray }} />
+            </View>
+
+            <View className="flex-1 items-center justify-center">
+              <Text style={[fonts.mediumText, { color: colors.black }]}>
+                상세 정보를 불러오는 중...
+              </Text>
+            </View>
+          </Animated.View>
+        </View>
+      </Modal>
+    );
+  }
 
   const { label: statusLabel, color: statusColor } = formatPartyStatus(
     party.status
@@ -82,8 +146,6 @@ export default function PartyBottomSheet({
     formatGender(party.gender),
   ];
 
-  const isHost = party.role === "HOST";
-  const isParticipant = party.role === "GUEST";
   const isJoined = party.role !== "NONE";
 
   const canViewChatLink =
@@ -199,7 +261,6 @@ export default function PartyBottomSheet({
 
             <PartyBottomSheetButton
               party={party}
-              memberId={member.memberId}
               onToggleLike={onToggleLike}
             />
           </View>

--- a/components/sections/PartyBottomSheet.tsx
+++ b/components/sections/PartyBottomSheet.tsx
@@ -78,7 +78,7 @@ export default function PartyBottomSheet({
   const tags = [
     formatDate(party.startAt),
     formatPartyType(party.type),
-    routeLabel,
+    ...(party.type !== "SCHEDULE_ONLY" ? [routeLabel] : []),
     formatGender(party.gender),
   ];
 
@@ -175,11 +175,13 @@ export default function PartyBottomSheet({
                 ))}
               </View>
 
-              <View className="bg-gray-200 rounded-xl px-4 py-3 mb-6">
-                <Text style={[fonts.smallText, { color: colors.black }]}>
-                  {party.description ?? "파티장님이 아직 소개를 작성하지 않았어요."}
-                </Text>
-              </View>
+              {party.description && (
+                <View className="bg-gray-200 rounded-xl px-4 py-3 mb-6">
+                  <Text style={[fonts.smallText, { color: colors.black }]}>
+                    {party.description}
+                  </Text>
+                </View>
+              )}
             </View>
 
             {canViewChatLink && (

--- a/components/sections/PartyBottomSheet.tsx
+++ b/components/sections/PartyBottomSheet.tsx
@@ -16,14 +16,14 @@ type PartyBottomSheetProps = {
   isVisible: boolean;  
   partyId: number | null;
   onClose: () => void;
-  onToggleLike?: (id: number) => void;
+  onToggleLike?: (id: number) => Promise<void>;
 };
 
 const { height } = Dimensions.get("window");
 const SHEET_HEIGHT = height * 0.72;
 const CLOSE_THRESHOLD = 70;
 
-export default function PartyBottomSheet({
+function PartyBottomSheet({
   isVisible,
   partyId,
   onClose,
@@ -36,17 +36,13 @@ export default function PartyBottomSheet({
 
   const panResponder = useRef(
   PanResponder.create({
-    onStartShouldSetPanResponder: () => true,
-    onMoveShouldSetPanResponder: (_, gestureState) => {
-      return Math.abs(gestureState.dy) > 5;
+    onStartShouldSetPanResponder: () => false,
+    onMoveShouldSetPanResponder: (_, g) => Math.abs(g.dy) > 5,
+    onPanResponderMove: (_, g) => {
+      if (g.dy > 0) translateY.setValue(g.dy);
     },
-    onPanResponderMove: (_, gestureState) => {
-      if (gestureState.dy > 0) {
-        translateY.setValue(gestureState.dy);
-      }
-    },
-    onPanResponderRelease: (_, gestureState) => {
-      if (gestureState.dy > CLOSE_THRESHOLD) {
+    onPanResponderRelease: (_, g) => {
+      if (g.dy > CLOSE_THRESHOLD) {
         Animated.timing(translateY, {
           toValue: SHEET_HEIGHT,
           duration: 200,
@@ -62,6 +58,11 @@ export default function PartyBottomSheet({
     },
   })
 ).current;
+
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
 
   useEffect(() => {
     Animated.timing(translateY, {
@@ -87,7 +88,7 @@ export default function PartyBottomSheet({
         console.warn("파티 상세 조회 실패:", e);
         if (!alive) return;
         setParty(null);
-        onClose();
+        onCloseRef.current(); 
       } finally {
         if (!alive) return;
         setIsLoading(false);
@@ -97,7 +98,21 @@ export default function PartyBottomSheet({
     return () => {
       alive = false;
     };
-  }, [isVisible, partyId, onClose]);
+  }, [isVisible, partyId]);
+
+  const handleToggleLikeInSheet = async (id: number) => {
+    if (!party) return;
+
+    const prevLiked = party.isLiked;
+
+    setParty((prev) => (prev ? { ...prev, isLiked: !prev.isLiked } : prev));
+
+    try {
+      await onToggleLike?.(id);
+    } catch (e) {
+      setParty((prev) => (prev ? { ...prev, isLiked: prevLiked } : prev));
+    }
+  };
 
   if (!isVisible) return null;
 
@@ -261,7 +276,7 @@ export default function PartyBottomSheet({
 
             <PartyBottomSheetButton
               party={party}
-              onToggleLike={onToggleLike}
+              onToggleLike={handleToggleLikeInSheet}
             />
           </View>
         </Animated.View>
@@ -269,3 +284,5 @@ export default function PartyBottomSheet({
     </Modal>
   );
 }
+
+export default React.memo(PartyBottomSheet);

--- a/components/sections/PartyBottomSheet.tsx
+++ b/components/sections/PartyBottomSheet.tsx
@@ -168,6 +168,16 @@ function PartyBottomSheet({
 
   const canShowReviewButton = party.status === "COMPLETED";
 
+  const refreshParty = async () => {
+    if (!partyId) return;
+    try {
+      const detail = await getPartyDetail(partyId);
+      setParty(detail);
+    } catch (e) {
+      console.warn("파티 상세 재조회 실패:", e);
+    }
+  };
+
   return (
     <Modal visible={isVisible} transparent animationType="fade" onRequestClose={onClose}>
       <View className="flex-1">
@@ -277,6 +287,7 @@ function PartyBottomSheet({
             <PartyBottomSheetButton
               party={party}
               onToggleLike={handleToggleLikeInSheet}
+              onConfirmed={refreshParty}
             />
           </View>
         </Animated.View>

--- a/components/sections/PartyCard.tsx
+++ b/components/sections/PartyCard.tsx
@@ -102,7 +102,7 @@ export default function PartyCard({ item, onToggleLike, onSelect, selectable = f
             <View className="flex-row flex-wrap mt-3">
               <Tag label={formatDate(item.startAt)} isSelected={selected} />
               <Tag label={formatPartyType(item.type)} isSelected={selected} />
-              <Tag label={routeLabel} isSelected={selected} />
+              {item.type !== "SCHEDULE_ONLY" && (<Tag label={routeLabel} isSelected={selected} />)}
               <Tag label={formatGender(item.gender)} isSelected={selected} />
             </View>
           </View>

--- a/components/toasts/ShortToast.tsx
+++ b/components/toasts/ShortToast.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { View, Text } from "react-native";
+import { View, Text, Dimensions } from "react-native";
 import { colors } from "@/constants/colors";
 import { fonts } from "@/constants/fonts";
+const { height } = Dimensions.get("window");
 
 type ShortToastProps = {
   message: string;
@@ -13,7 +14,10 @@ export default function ShortToast({ message }: ShortToastProps) {
         className="absolute left-0 right-0 items-center"
         style={{
           position: "absolute",
-          top: -10,
+          left: 0,
+          right: 0,
+          bottom: 80,
+          alignItems: "center",
           zIndex: 9999,
           elevation: 9999,
       }}

--- a/components/toasts/ShortToast.tsx
+++ b/components/toasts/ShortToast.tsx
@@ -12,6 +12,7 @@ export default function ShortToast({ message }: ShortToastProps) {
     <View 
         className="absolute left-0 right-0 items-center"
         style={{
+          position: "absolute",
           top: -10,
           zIndex: 9999,
           elevation: 9999,

--- a/stores/useMyLocationStore.ts
+++ b/stores/useMyLocationStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import type { MyLocation } from "@/types/kakao-place";
+import type { MyLocation } from "@/types/place";
 
 type MyLocationState = {
   myLocation: MyLocation | null;

--- a/types/party.ts
+++ b/types/party.ts
@@ -1,3 +1,5 @@
+import type { Place } from "@/types/place";
+
 export type PartyStatus = 'RECRUITING' | 'RECRUIT_COMPLETED' | 'COMPLETED';
 export type PartyType = 'SCHEDULE_AND_TRANSPORT' | 'SCHEDULE_ONLY' | 'TRANSPORT_ONLY';
 export type GenderType = 'MALE' | 'FEMALE' | 'ALL';
@@ -10,14 +12,6 @@ export type PartyMember = {
   nickname: string | null;
   profileImage: number | null;
   role: HostRole;
-};
-
-export type Place = {
-  placeName: string;
-  addressName: string;
-  roadAddressName: string;
-  latitude: number;
-  longitude: number;
 };
 
 export interface PartyItem {

--- a/types/place.ts
+++ b/types/place.ts
@@ -10,6 +10,14 @@ export type KakaoPlace = {
   phone: string;
 };
 
+export type Place = {
+  placeName: string;
+  addressName: string;
+  roadAddressName: string;
+  latitude: number;
+  longitude: number;
+};
+
 export type MyLocation = {
   placeName: string;
   addressName: string;

--- a/types/response.ts
+++ b/types/response.ts
@@ -1,0 +1,18 @@
+export type SliceResponse<T> = {
+  content: T[];
+  last: boolean;
+  first: boolean;
+  empty: boolean;
+  number: number;
+  size: number;
+  numberOfElements: number;
+  pageable?: unknown;
+  sort?: unknown;
+};
+
+export type ApiResponse<T> = {
+  data: T;
+  status: number;
+  success: boolean;
+  timestamp: string;
+};

--- a/utils/dateTime.ts
+++ b/utils/dateTime.ts
@@ -40,7 +40,9 @@ export const getDateRange = (start: string, end: string) => {
 };
 
 export const toKSTIsoString = (date: string, time: string) => {
-  if (!date || !time) return null;
+  if (!date || !time) {
+    throw new Error("toKSTIsoString: date/time is required");
+  }
 
   const [hour, minute] = time.split(":").map(Number);
 


### PR DESCRIPTION
## 🔷 관련 Jira Ticket ID

[KU-118]

---
## 📌 작업 내용 및 특이사항

- **파티 생성**
  - 파티 유형(`SCHEDULE_AND_TRANSPORT`/`SCHEDULE_ONLY`/`TRANSPORT_ONLY`)에 따라 입력 필드 및 유효성 조건을 분기 처리
  - 입력값이 유효하지 않을 경우: [생성하기] 버튼 비활성화
- **행사별 파티 목록 조회**
- **나의 파티 목록 조회**
  - 파티 목록 화면: 탭 별 상태(파티 데이터, cursor, hasMore) 분리해서 관리, 무한스크롤 적용
    - 전체(ALL): 내가 참여한 파티 목록 조회(participant)
    - MY: 내가 만든 파티 목록 조회(host)
- **관심 파티**
  - **파티 찜하기**: 찜/찜 취소 토글 방식으로 구현
    - PartyCard, PartyBottomSheet 컴포넌트에 적용
  - **관심 파티 목록 조회**: partyData, cursor, hasMore 상태 관리하여 무한스크롤 적용
- (participant) **파티 참여/참여 취소**
- (host) **파티 참여 승인/거절**
- (host) **파티 확정 + 오픈채팅방 링크 추가** : 오픈채팅방 링크 입력 모달을 통해 `chatUrl`을 입력받고 형식 검증 후 API 호출

---
## 📚 참고사항

- **파티 생성 입력 컴포넌트 수정**
  - partyType가 `SCHEDULE_ONLY` 일때 '이동 형태' 컴포넌트 숨김처리
-  PartyBottomSheet 컴포넌트를 `partyId` 기반 파티 상세 조회 하도록 로직 변경

[KU-118]: https://judymoody59.atlassian.net/browse/KU-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ